### PR TITLE
switching to setuptools to aid in development 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-from distutils.core import setup
+from setuptools import setup
 
 VERSION='0.6.3'
 


### PR DESCRIPTION
I found this helpful when developing on PyFTDI - it allows 'python setup.py develop' to set up a live link to development repo. Otherwise it works the same as using distutils.core - this is the current recommended way to implement a setup.py script.

cheers
adam
