### PR TITLE
Fix for having multiple same-model FTDI chips with different serial numbers connected at the same time

### DIFF
--- a/pyftdi/pyftdi/usbtools.py
+++ b/pyftdi/pyftdi/usbtools.py
@@ -97,7 +97,10 @@ class UsbTools(object):
                             break
                         except usb.core.USBError, e:
                             pass
-                dev.set_configuration()
+                try:
+                  dev.set_configuration()
+                except usb.core.USBError, e:
+                   pass # if there is no such device, it's probably already been detached (2 or more FTDI chips attached)
                 cls.DEVICES[devkey] = [dev, 1]
             else:
                 cls.DEVICES[devkey][1] += 1


### PR DESCRIPTION
If you have multiple same-model FTDI chips with different serial numbers connected and using PyFTDI
at the same time, you get an exception:

serial.serialutil.SerialException: Unable to open USB port ftdi://ftdi:ft232h:FTVO7KZ3/1

This is caused by an underlying USBError - because the first PyFTDI does dev.set_configuration(),
which detaches the device driver, then the second PyFTDI tries to do the same, causing an
exception.

This fix now ignores USBError when trying to dev.set_configuration() while in 
get_device() - this probably means there are more than one of the same
kind of FTDI device connected, and the driver has already been detached.

