### PR TITLE
Adapt to API breaking changes in pyusb

### DIFF
--- a/pyftdi/pyftdi/ftdi.py
+++ b/pyftdi/pyftdi/ftdi.py
@@ -574,7 +574,6 @@ class Ftdi(object):
                     write_size = size - offset
                 length = self.usb_dev.write(self.in_ep,
                                             data[offset:offset+write_size],
-                                            self.interface,
                                             self.usb_write_timeout)
                 if length <= 0:
                     raise FtdiError("Usb bulk write error")
@@ -609,7 +608,6 @@ class Ftdi(object):
                 while True:
                     tempbuf = self.usb_dev.read(self.out_ep,
                                                 self.readbuffer_chunksize,
-                                                self.interface,
                                                 self.usb_read_timeout)
                     attempt -= 1
                     length = len(tempbuf)

--- a/pyftdi/pyftdi/usbtools.py
+++ b/pyftdi/pyftdi/usbtools.py
@@ -47,8 +47,8 @@ class UsbTools(object):
         devs = UsbTools._find_devices(vps, nocache)
         for dev in devs:
             ifcount = max([cfg.bNumInterfaces for cfg in dev])
-            sernum = usb.util.get_string(dev, 64, dev.iSerialNumber)
-            description = usb.util.get_string(dev, 64, dev.iProduct)
+            sernum = usb.util.get_string(dev, dev.iSerialNumber)
+            description = usb.util.get_string(dev, dev.iProduct)
             devices.append((dev.idVendor, dev.idProduct, sernum, ifcount,
                             description))
         return devices
@@ -67,11 +67,11 @@ class UsbTools(object):
                 devs = cls._find_devices(vps)
                 if description:
                     devs = [dev for dev in devs if \
-                              usb.util.get_string(dev, 64, dev.iProduct) \
+                              usb.util.get_string(dev, dev.iProduct) \
                                 == description]
                 if serial:
                     devs = [dev for dev in devs if \
-                              usb.util.get_string(dev, 64, dev.iSerialNumber) \
+                              usb.util.get_string(dev, dev.iSerialNumber) \
                                 == serial]
                 try:
                     dev = devs[index]


### PR DESCRIPTION
pyusb.usb.util.getstring() does not accept a `length` argument anymore.
pyusb.usb.core.Device.read() and write() methods do not accept an `interface`
argument anymore.

This is an issue/pull request. I went with the changes that broke my usage of pyftdi. I haven't groked everything about pyftdi or pyusb, so it may not be exhaustive or correct. It also obviously break pyftdi for pyusb <= 1.0.0b1.
