### PR TITLE
Fixed wrapping for different PyUSB API

### DIFF
--- a/pyftdi/pyftdi/ftdi.py
+++ b/pyftdi/pyftdi/ftdi.py
@@ -725,13 +725,12 @@ class Ftdi(object):
 
     def _wrap_api(self):
         """Deal with PyUSB API breaks"""
-        usb_api = 2
-        try:
-            from usb import version_info
-            if version_info[3] == 'b1':
-                usb_api = 1
-        except (ImportError, IndexError), e:
-            pass
+        import inspect
+        args, varargs, varkw, defaults = inspect.getargspec(usb.core.Device.read)
+        if "interface" in args :
+            usb_api = 1			# Require "interface" parameter
+        else :
+            usb_api = 2
         for m in ('write', 'read'):
             setattr(self, '_%s' % m, getattr(self, '_%s_v%d' % (m, usb_api)))
 


### PR DESCRIPTION
The _wrap_api function does not work with older versions of PyUSB, and may not work with newer ones.  This change looks directly at the ABI to determine if the "interface" parameter is needed or not.
