### PR TITLE
Update JEDEC information for lower density of W25Q series.

### DIFF
--- a/examples/spi/serialflash.py
+++ b/examples/spi/serialflash.py
@@ -766,7 +766,7 @@ class W25xFlashDevice(_Gen25FlashDevice):
 
     JEDEC_ID = 0xEF
     DEVICES = { 0x30 : 'W25X', 0x40 : 'W25Q' }
-    SIZES = { 0x15 : 2<<20, 0x16 : 4<<20, 0x17 : 8<<20 }
+    SIZES = {0x11: 1 << 17, 0x12: 1 << 18, 0x13: 1 << 19, 0x14 : 1 << 20, 0x15 : 2<<20, 0x16 : 4<<20, 0x17 : 8<<20 }
     SPI_FREQ_MAX = 104 # MHz
     CMD_READ_UID = 0x4B
     UID_LEN = 0x8 # 64 bits
@@ -1183,7 +1183,7 @@ class N25QFlashDevice(_Gen25FlashDevice):
         self._enable_write()
         for sector in xrange(len(self)>>16):
             addr = sector<<16
-            wcmd = Array('B', [self.CMD_WRLR, 
+            wcmd = Array('B', [self.CMD_WRLR,
                                (addr>>16) & 0xff,
                                (addr>>8) & 0xff,
                                (addr>>0) & 0xff,


### PR DESCRIPTION
While testing with a 8MB device, I noticed it was not being recognized.  Upon further
investigation, the JEDEC info across all devices didn't seem to be correct.
