### PR TITLE
Fix returning from read prematurely

### DIFF
--- a/pyftdi/serialext/serialusb.py
+++ b/pyftdi/serialext/serialusb.py
@@ -79,10 +79,7 @@ class UsbSerial(SerialBase):
             data += buf
             size -= len(buf)
             if self._timeout > 0:
-                if buf:
-                    break
-                ms = time.time()-start
-                if ms > self._timeout:
+                if time.time() - start > self._timeout:
                     break
             time.sleep(0.01)
         return data


### PR DESCRIPTION
I think the `read` function should wait at least `timeout` regardless of the partially read data. This commit forces to wait for `timeout`.