### PR TITLE
Enable to poll I2C with either R/W bit 1 or 0

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -134,12 +134,12 @@ class I2cPort(object):
         return self._controller.exchange(self._address+self._shift, out,
                                          readlen)
 
-    def poll(self):
+    def poll(self, read=True):
         """Poll a remote slave, expect ACK or NACK.
 
            :return: True if the slave acknowledged, False otherwise
         """
-        return self._controller.poll(self._address+self._shift)
+        return self._controller.poll(self._address+self._shift, read)
 
     def flush(self):
         """Force the flush of the HW FIFOs.
@@ -379,7 +379,7 @@ class I2cController(object):
             finally:
                 self._do_epilog()
 
-    def poll(self, address):
+    def poll(self, address, read=True):
         """Poll a remote slave, expect ACK or NACK.
 
            :param address: the address on the I2C bus
@@ -389,7 +389,8 @@ class I2cController(object):
             raise I2cIOError("FTDI controller not initialized")
         self.validate_address(address)
         i2caddress = (address << 1) & self.HIGH
-        i2caddress |= self.BIT0
+        if read:
+            i2caddress |= self.BIT0
         self.log.debug('- poll 0x%x', i2caddress >> 1)
         try:
             self._do_prolog(i2caddress)


### PR DESCRIPTION
I have an EEPROM that want's to be polled in WRITE mode, i.e. R/W set to 0.
Currently, pyftdi only allows polling in READ mode. I added an extra parameter to the poll methods, so the user can choose to poll in WRITE mode.
I set the default of this parameter to READ mode, so the change is backwards-compatible.