### PR TITLE
Tristate SDA pin during ACK in I2C mode for non-drive-zero devices

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -201,6 +201,7 @@ class I2cController(object):
         self._ack = (Ftdi.WRITE_BITS_NVE_MSB, 0, self.LOW)
         self._start = data_low*4 + clock_low_data_low*4
         self._stop = clock_low_data_low*4 + data_low*4 + self._idle*4
+        self._tristate = (Ftdi.SET_BITS_LOW, self.LOW, self.SCL_BIT)
         self._tx_size = 1
         self._rx_size = 1
 
@@ -237,7 +238,9 @@ class I2cController(object):
                                              self.SDA_O_BIT |
                                              self.SDA_I_BIT)
         except FtdiFeatureError:
-            if not bool(kwargs.get('notristate', True)):
+            if bool(kwargs.get('softtristate', True)):
+                self._soft_tristate = True
+            elif not bool(kwargs.get('notristate', True)):
                 raise
 
     def terminate(self):
@@ -415,8 +418,13 @@ class I2cController(object):
         cmd.extend(self._start)
         cmd.extend(self._write_byte)
         cmd.append(i2caddress)
-        cmd.extend(self._clock_low_data_high)
-        cmd.extend(self._read_bit)
+        if self._soft_tristate:
+            cmd.extend(self._tristate)
+            cmd.extend(self._read_bit)
+            cmd.extend(self._clock_low_data_high)
+        else:
+            cmd.extend(self._clock_low_data_high)
+            cmd.extend(self._read_bit)
         cmd.extend(self._immediate)
         self._ftdi.write_data(cmd)
         ack = self._ftdi.read_data_bytes(1, 4)
@@ -435,8 +443,13 @@ class I2cController(object):
 
     def _do_read(self, readlen):
         self.log.debug('- read %d bytes', readlen)
-        read_not_last = self._read_byte + self._ack + self._clock_low_data_high
-        read_last = self._read_byte + self._nack + self._clock_low_data_high
+        if self._soft_tristate:
+            read_byte = self._tristate + self._read_byte + self._clock_low_data_high
+            read_not_last = read_byte + self._ack
+            read_last = read_byte + self._nack
+        else:
+            read_not_last = self._read_byte + self._ack + self._clock_low_data_high
+            read_last = self._read_byte + self._nack + self._clock_low_data_high
         chunk_size = self._rx_size-2
         cmd_size = len(read_last)
         # limit RX chunk size to the count of I2C packable ommands in the FTDI
@@ -470,8 +483,13 @@ class I2cController(object):
         for byte in out:
             cmd = Array('B', self._write_byte)
             cmd.append(byte)
-            cmd.extend(self._clock_low_data_high)
-            cmd.extend(self._read_bit)
+            if self._soft_tristate:
+                cmd.extend(self._tristate)
+                cmd.extend(self._read_bit)
+                cmd.extend(self._clock_low_data_high)
+            else:
+                cmd.extend(self._clock_low_data_high)
+                cmd.extend(self._read_bit)
             cmd.extend(self._immediate)
             self._ftdi.write_data(cmd)
             ack = self._ftdi.read_data_bytes(1, 4)


### PR DESCRIPTION
This patch configures the SDA pin as input when the I2C slave puts
its N/ACK on the wire. This is so non "drive-zero" hardware (like
the 2232H) can be used to communicate with I2C devices without
hardware overhead. A current-limiting resistor on the I2C line is
still recommended (10-250 ohms, depending on your wire length and
supply voltage). This method is also used by FTDI themselves, for
example in their application note AN 411: "For the FT2232H and
FT4232H, the application includes additional GPIO writes to ADBUS
which tristate the AD1 Data Out pin when the line is not being
driven, to simulate an open-drain pin." It has also been discussed
and reported as working in Issue #46.
I'm not really a python programmer, so there's probably a more
idiomatic way to express this stuff :)
This feature has to be explicitly enabled by setting 'softtrisate'.
I'm not really sure that this is a sensible default, but I didn't want
to change previous behavior either.