### PR TITLE
more links and another libusb on windows link

### DIFF
--- a/pyftdi/README.rst
+++ b/pyftdi/README.rst
@@ -113,9 +113,9 @@ Supported features
   Mode   CPol   CPha  Status
   =====  ===== ====== ====================================================
     0      0      0   Supported on all MPSEE devices
-    1      0      1   Supported on -H series (FT232H/FT2232H/FT4232H)
+    1      0      1   Supported on -H series (FT232H_/FT2232H_/FT4232H_)
     2      1      0   Not supported (FTDI HW limitation)
-    3      1      1   Supported on -H series (FT232H/FT2232H/FT4232H)
+    3      1      1   Supported on -H series (FT232H_/FT2232H_/FT4232H_)
   =====  ===== ====== ====================================================
 
   PyFtdi_ can be used with pyspiflash_ module that demonstrates how to
@@ -126,7 +126,7 @@ Supported features
 
 * |I2C| master. For now, only 7-bit address are supported.
 
-  Supported devices: FT232H, FT2232H, FT4232H
+  Supported devices: FT232H_, FT2232H_, FT4232H_
 
 * JTAG is under development and is not fully supported yet.
 
@@ -199,8 +199,8 @@ FTDI device pinout
           is bi-directional, two FTDI pins are required to provide the SDA
           feature, and they should be connected together and to the SDA |I2C|
           bus line. Pull-up resistors on SCK and SDA lines should be used.
-.. [#if2] FTDI232H does not support a secondary MPSSE port, only FT2232H and
-          FT4232H do. Note that FTDI4232H has 4 serial ports, but only the first
+.. [#if2] FTDI232H_ does not support a secondary MPSSE port, only FT2232H_ and
+          FT4232H_ do. Note that FTDI4232H_ has 4 serial ports, but only the first
           two interfaces are MPSSE-capable.
 
 API Overview

--- a/pyftdi/README.rst
+++ b/pyftdi/README.rst
@@ -415,4 +415,4 @@ Examples
 .. _pyi2cflash: https://github.com/eblot/pyi2cflash/
 .. _libusb: http://www.libusb.info/
 .. _macos_guide: http://www.ftdichip.com/Support/Documents/AppNotes/AN_134_FTDI_Drivers_Installation_Guide_for_MAC_OSX.pdf
-.. _Libusb on Windows: http://libusb.org/wiki/windows_backend
+.. _Libusb on Windows: https://github.com/libusb/libusb/wiki/Windows


### PR DESCRIPTION
it seems to me like http://libusb.org/wiki/windows_backend is not so actual (last edit two years ago)
while https://github.com/libusb/libusb/wiki/Windows seems more actual