### PR TITLE
Return the same type for read and exchange in I2C

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -298,7 +298,7 @@ class I2cController(object):
             try:
                 self._do_prolog(i2caddress)
                 data = self._do_read(readlen)
-                return bytes(data)
+                return data
             except I2cNackError:
                 retries -= 1
                 if not retries:
@@ -369,7 +369,7 @@ class I2cController(object):
                 self._do_write(out)
                 self._do_prolog(i2caddress | self.BIT0)
                 data = self._do_read(readlen)
-                return bytes(data)
+                return data
             except I2cNackError:
                 retries -= 1
                 if not retries:

--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -369,7 +369,7 @@ class I2cController(object):
                 self._do_write(out)
                 self._do_prolog(i2caddress | self.BIT0)
                 data = self._do_read(readlen)
-                return data
+                return bytes(data)
             except I2cNackError:
                 retries -= 1
                 if not retries:


### PR DESCRIPTION
read() returns bytes whereas exchange() returns array. This prevents me from doing:
data = exchange()
data += read()
And it's kind of an inconsistent interface.
This commit changes the type of the return of exchange() from array to bytes.