### PR TITLE
SPI losing bit

### DIFF
--- a/pyftdi/spi.py
+++ b/pyftdi/spi.py
@@ -295,15 +295,10 @@ class SpiController(object):
             self._clock_phase = cpha
         if writelen:
             wcmd = (cpol ^ cpha) and \
-                Ftdi.WRITE_BYTES_PVE_MSB or Ftdi.WRITE_BYTES_NVE_MSB
+                Ftdi.RW_BYTES_NVE_PVE_MSB or Ftdi.RW_BYTES_PVE_NVE_MSB 
             write_cmd = struct.pack('<BH', wcmd, writelen-1)
             cmd.frombytes(write_cmd)
             cmd.extend(out)
-        if readlen:
-            rcmd = (cpol ^ cpha) and \
-                Ftdi.READ_BYTES_PVE_MSB or Ftdi.READ_BYTES_NVE_MSB
-            read_cmd = struct.pack('<BH', rcmd, readlen-1)
-            cmd.frombytes(read_cmd)
             cmd.extend(self._immediate)
             if self._turbo:
                 if epilog:
@@ -316,18 +311,7 @@ class SpiController(object):
             # USB read cycle may occur before the FTDI device has actually
             # sent the data, so try to read more than once if no data is
             # actually received
-            data = self._ftdi.read_data_bytes(readlen, 4)
-        else:
-            if writelen:
-                if self._turbo:
-                    if epilog:
-                        cmd.extend(epilog)
-                    self._ftdi.write_data(cmd)
-                else:
-                    self._ftdi.write_data(cmd)
-                    if epilog:
-                        self._ftdi.write_data(epilog)
-            data = array('B')
+            data = self._ftdi.read_data_bytes(writelen, 4)
         return data
 
     def _flush(self):


### PR DESCRIPTION
I'm using the CI MCP3008 (10-Bit A/D Converters) but I was always losing the fist bit (I got only 9-Bits) and got all bits inverted (0' becomes 1' and 1' becomes 0'). Although I have already used this CI with Arduino and Raspberry, it's fail on FT232H. 

After hour debugging,  I realize that the command to write  precede the command to read, thus the time between both command to be received and processed is very short but enough to lose one bit. By this way, the only way to solve this was send the command to FT device to start read and write at the same time. 

After solving the losing bit, the inverted bits problem disappear.

Probability it can help with mode 2 issue if we include one way to manage the initial clock's polarity. (Unfortunately I don't have any device that operate with mode 2 to test )

Finally, the code should be revised to distinguish between read/write operation and write only operation.

Regards