### PR TITLE
serialext: Fix timeout interpretation

### DIFF
--- a/pyftdi/serialext/protocol_ftdi.py
+++ b/pyftdi/serialext/protocol_ftdi.py
@@ -73,7 +73,7 @@ class FtdiSerial(SerialBase):
             buf = self.udev.read_data(size)
             data += buf
             size -= len(buf)
-            if self._timeout > 0:
+            if self._timeout is not None:
                 if buf:
                     break
                 ms = now()-start


### PR DESCRIPTION
According to the pySerial API documentation, the possible values for the
timeout parameter are:

* `timeout = None`: wait forever / until requested number of bytes are
  received;
* `timeout = 0`: non-blocking mode, return immediately in any case,
  returning zero or more, up to the requested number of bytes;
* `timeout = x`: set timeout to x seconds (float allowed) returns
  immediately when the requested number of bytes are available,
  otherwise wait until the timeout expires and return all bytes that
  were received until then.

The FtdiSerial class did not comply with this specification, as it
treated timeout = 0 as wait forever, and crashes when timeout is None.