### PR TITLE
serialext: Do not sleep when all requested data is read

### DIFF
--- a/pyftdi/serialext/protocol_ftdi.py
+++ b/pyftdi/serialext/protocol_ftdi.py
@@ -69,10 +69,12 @@ class FtdiSerial(SerialBase):
            until the requested number of bytes is read."""
         data = bytearray()
         start = now()
-        while size > 0:
+        while True:
             buf = self.udev.read_data(size)
             data += buf
             size -= len(buf)
+            if size == 0:
+                break
             if self._timeout is not None:
                 if buf:
                     break


### PR DESCRIPTION
FtdiSerial.read() would always sleep for 10ms at each loop iteration,
even when all requested data has been retrieved.  Hence, small reads are
penalized, even though they should be competitive with larger reads
thanks to the read buffer inside the Ftdi device object.

This patch provides a quick exit path in FtdiSerial.read() as soon as
all requested data is read.