### PR TITLE
jtag: Fix syntax problem when configuring JtagEngine

### DIFF
--- a/pyftdi/jtag.py
+++ b/pyftdi/jtag.py
@@ -419,8 +419,11 @@ class JtagEngine(object):
 
     def configure(self, vendor=0x0403, product=0x6011, interface=0):
         """Configure the FTDI interface as a JTAG controller"""
-        self._ctrl.configure(vendor=vendor, product=product,
-                             interface=interface)
+        if vendor == 0 and product == 0:
+            url = "ftdi:///?"       # Enumerate all the FTDI devices
+        else:
+            url = "ftdi://" + hex(vendor) + ":" + hex(product) + "/" + str(interface)
+        self._ctrl.configure(url)
 
     def close(self):
         """Terminate a JTAG session/connection"""


### PR DESCRIPTION
The configure call on _ctrl object must be done with a URL.
If product and vendor ID are set to 0, it will enumerate all the available FTDI devices.