### PR TITLE
packaging: fix license file path in setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 python-tag = py35
 
 [metadata]
-license_file = pyftdi/LICENSE
+license_file = pyftdi/doc/licenses.rst
 
 [build_sphinx]
 source-dir = pyftdi/doc


### PR DESCRIPTION
fixes the following error on 'pip install':
```
error: [Errno 2] No such file or directory: 'pyftdi/LICENSE'
Failed building wheel
```
