### PR TITLE
Fix busy ports

### DIFF
--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -443,6 +443,12 @@ class Ftdi:
         if self.usb_dev:
             self.set_bitmode(0, Ftdi.BITMODE_RESET)
             self.set_latency_timer(self.LATENCY_MAX)
+            self.usb_dev._ctx.managed_release_interface(self.usb_dev,
+                                                        self.index - 1)
+            try:
+                self.usb_dev.attach_kernel_driver(self.index - 1)
+            except (NotImplementedError, usb.core.USBError):
+                pass
             UsbTools.release_device(self.usb_dev)
             self.usb_dev = None
 

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -1404,6 +1404,13 @@ class Ftdi:
         endpoints = sorted([ep.bEndpointAddress for ep in self.interface])
         self.in_ep, self.out_ep = endpoints[:2]
 
+        # detach kernel driver from the interface
+        try:
+            if self.usb_dev.is_kernel_driver_active(self.index - 1):
+                self.usb_dev.detach_kernel_driver(self.index - 1)
+        except (NotImplementedError, usb.core.USBError):
+            pass
+
     def _reset_device(self):
         """Reset the ftdi device"""
         if self._ctrl_transfer_out(Ftdi.SIO_RESET, Ftdi.SIO_RESET_SIO):

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -147,20 +147,6 @@ class UsbTools:
             except AttributeError:
                 devkey = (vendor, product)
             if devkey not in cls.Devices:
-                for configuration in dev:
-                    # we need to detach any kernel driver from the device
-                    # be greedy: reclaim all device interfaces from the kernel
-                    for interface in configuration:
-                        ifnum = interface.bInterfaceNumber
-                        try:
-                            if not dev.is_kernel_driver_active(ifnum):
-                                continue
-                            dev.detach_kernel_driver(ifnum)
-                        except NotImplementedError:
-                            # only libusb 1.x backend implements this method
-                            break
-                        except usb.core.USBError:
-                            pass
                 # only change the active configuration if the active one is
                 # not the first. This allows other libusb sessions running
                 # with the same device to run seamlessly.


### PR DESCRIPTION
These two patches allows pyftdi to work together with OS drivers: 
* detach only the kernel drivers on a per interface (FTDI port) basis to allow some ports being used by the host and some by pyftdi
* reattach kernel drivers when we are done with the interface to allow the host driver accessing the port when pyftdi is done

Tested on Linux only.