### PR TITLE
RFC: usbtools: only detach kernel drivers from used interfaces

### DIFF
--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -422,7 +422,7 @@ class Ftdi:
                               by its serial number
            :param str interface: FTDI interface/port
         """
-        self.usb_dev = UsbTools.get_device(vendor, product, index, serial)
+        self.usb_dev = UsbTools.get_device(vendor, product, index, serial, interface=interface)
         try:
             self.usb_dev.set_configuration()
         except usb.core.USBError:


### PR DESCRIPTION
Without this patch opening any interface on a multi-interface device like
the FT4232H detaches all kernel drivers from all interfaces. Thus other
interfaces can no longer be used as native serial ports.

This patch adds the needed functionality to usbtools.UsbTools.get_device()
to only detach drivers from the interface that is actually being opened.
If this function is called without the interface-argument it behaves as
before.
According to the existing docstring the used parameter has been planned or
used before.

This patch also modifies the ftdi.Ftdi.open() function to pass the used
interface to usbtools.UsbTools.get_device().

Code-paths that are not aware of the interface to use (for example via
ftdi.Ftdi.get_device()) should behave as before and detach drivers from all
interfaces.

This patch works fine for my use case (using I2C on interface 1 on a FT4232H). Since I am not sure if this will work with other use cases or hardware setups I submit this patch as RFC.

Signed-off-by: Chris Fiege <cfi@pengutronix.de>