### PR TITLE
the sleep period on read

### DIFF
--- a/pyftdi/serialext/serialusb.py
+++ b/pyftdi/serialext/serialusb.py
@@ -89,7 +89,7 @@ class UsbSerial(SerialBase):
                 ms = time.time()-start
                 if ms > self._timeout:
                     break
-            time.sleep(0.01)
+            time.sleep(0.0001)
         return data
 
     def write(self, data):


### PR DESCRIPTION
the hard coded sleep in SerialUsb read function is too long for time sensitive applications. Reducing it to a significantly smaller value. Before this change I had unexplained 10 mili second delays in my communications, which is resolved by the change.