### PR TITLE
Fixed broken SPI GPIO example

### DIFF
--- a/pyftdi/doc/api/spi.rst
+++ b/pyftdi/doc/api/spi.rst
@@ -12,7 +12,7 @@ Example: communication with a SPI data flash (half-duplex example)
 
 .. code-block:: python
 
-    # Instanciate a SPI controller
+    # Instantiate a SPI controller
     spi = SpiController()
 
     # Configure the first interface (IF/1) of the FTDI device as a SPI master
@@ -29,7 +29,7 @@ Example: communication with a remote SPI device using full-duplex mode
 
 .. code-block:: python
 
-    # Instanciate a SPI controller
+    # Instantiate a SPI controller
     spi = SpiController()
 
     # Configure the first interface (IF/1) of the FTDI device as a SPI master
@@ -48,8 +48,8 @@ Example: communication with a SPI device and an extra GPIO
 
 .. code-block:: python
 
-    # Instanciate a SPI controller
-    spi = SpiController()
+    # Instantiate a SPI controller with a single CS line
+    spi = SpiController(cs_count=1)
 
     # Configure the first interface (IF/1) of the first FTDI device as a
     # SPI master


### PR DESCRIPTION
Addresses issue #109 

Copying the docs verbatim results in an error, because the GPIO pin used conflicts with one of the 4 CS pins that are reserved by default.
Updating the docs to reflect to reduce the amount of CS pins to 1 for this example only seems like the best solution, instead of a breaking API change