### PR TITLE
Allow opening FTDI connections to specific USB devices

### DIFF
--- a/pyftdi/doc/api/i2c.rst
+++ b/pyftdi/doc/api/i2c.rst
@@ -32,6 +32,19 @@ Example: communication with an |I2C| GPIO expander
     # Read a register from the I2C slave
     slave.read_from(0x00, 1)
 
+Example: creating an |I2C| controller from an existing FTDI device
+
+.. code-block:: python
+
+    # Open an FTDI device
+    ftdi = Ftdi.create_from_url('ftdi://ftdi:2232h/1')
+
+    # Instanciate an I2C controller from an existing FTDI device
+    i2c = I2cController(ftdi)
+
+    # Configure the FTDI device as an I2C master
+    i2c.configure()
+
 Example: mastering the |I2C| bus with a complex transaction
 
 .. code-block:: python

--- a/pyftdi/doc/urlscheme.rst
+++ b/pyftdi/doc/urlscheme.rst
@@ -74,6 +74,19 @@ parameters (among others).
    v0.22.0, be sure to update your code.
 
 
+It is also possible to open a connection to a specific ``usb.core.Device``
+that may have been obtained elsewhere, by passing the USB device object to the
+Ftdi constructor.
+
+.. code-block:: python
+
+   # find a USB device matching the given vendor and product IDs
+   device = usb.core.find(idVendor = 0x0403, idProduct = 0x6011)
+
+   # open a connection to interface 1 of the given USB device
+   ftdi = Ftdi(device, 1)
+
+
 Supporting custom USB vendor and product IDs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -258,9 +258,9 @@ class Ftdi:
     LATENCY_MIN = 12
     LATENCY_MAX = 255
 
-    def __init__(self):
+    def __init__(self, device = None, interface = 1):
         self.log = getLogger('pyftdi.ftdi')
-        self.usb_dev = None
+        self.usb_dev = device
         self.usb_read_timeout = 5000
         self.usb_write_timeout = 5000
         self.baudrate = -1

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -518,6 +518,33 @@ class Ftdi:
         """
         # Open an FTDI interface
         self.open(vendor, product, index, serial, interface)
+
+        return self.init_mpsse(interface, direction, initial, frequency,
+                               lacency, debug)
+
+    def init_mpsse(self, interface=1, direction=0x0, initial=0x0,
+                   frequency=6.0E6, latency=16, debug=False):
+        """Initialize an interface to the FTDI in MPSSE mode.
+
+           MPSSE enables I2C, SPI, JTAG or other synchronous serial interface
+           modes (vs. UART mode).
+
+           Some FTDI devices support several interfaces/ports (such as FT2232H
+           and FT4232H). The interface argument selects the FTDI port to use,
+           starting from 1 (not 0). Note that not all FTDI ports are MPSSE
+           capable.
+
+           :param str interface: FTDI interface/port
+           :param int direction: a bitfield specifying the FTDI GPIO direction,
+                where high level defines an output, and low level defines an
+                input
+           :param int initial: a bitfield specifying the initial output value
+           :param float frequency: serial interface clock in Hz
+           :param int latency: low-level latency in milliseconds. The shorter
+                the delay, the higher the host CPU load. Do not use shorter
+                values than the default, as it triggers data loss in FTDI.
+           :param bool debug: use a tracer to decode MPSSE protocol
+        """
         if not self.has_mpsse:
             self.close()
             raise FtdiMpsseError('This device does not support MPSSE')

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -399,6 +399,22 @@ class Ftdi:
         vendor, product, index, serial, interface = self.get_identifiers(url)
         self.open(vendor, product, index, serial, interface)
 
+    def init(self, interface = 1):
+        try:
+            self.usb_dev.set_configuration()
+        except usb.core.USBError:
+            pass
+        # detect invalid interface as early as possible
+        config = self.usb_dev.get_active_configuration()
+        if interface > config.bNumInterfaces:
+            raise FtdiError('No such FTDI port: %d' % interface)
+        self._set_interface(config, interface)
+        self.max_packet_size = self._get_max_packet_size()
+        # Drain input buffer
+        self.purge_buffers()
+        self._reset_device()
+        self.set_latency_timer(self.LATENCY_MIN)
+
     def open(self, vendor, product, index=0, serial=None, interface=1):
         """Open a new interface to the specified FTDI device.
 
@@ -423,20 +439,8 @@ class Ftdi:
            :param str interface: FTDI interface/port
         """
         self.usb_dev = UsbTools.get_device(vendor, product, index, serial)
-        try:
-            self.usb_dev.set_configuration()
-        except usb.core.USBError:
-            pass
-        # detect invalid interface as early as possible
-        config = self.usb_dev.get_active_configuration()
-        if interface > config.bNumInterfaces:
-            raise FtdiError('No such FTDI port: %d' % interface)
-        self._set_interface(config, interface)
-        self.max_packet_size = self._get_max_packet_size()
-        # Drain input buffer
-        self.purge_buffers()
-        self._reset_device()
-        self.set_latency_timer(self.LATENCY_MIN)
+
+        return self.init(interface)
 
     def close(self):
         """Close the FTDI interface/port."""

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -58,14 +58,14 @@ class UsbTools:
         devs = set()
         for v, p in vps:
             devs.update(UsbTools._find_devices(v, p, nocache))
-        devices = set()
+        devices = []
         for dev in devs:
             ifcount = max([cfg.bNumInterfaces for cfg in dev])
             sernum = UsbTools.get_string(dev, dev.iSerialNumber)
             description = UsbTools.get_string(dev, dev.iProduct)
-            devices.add((dev.idVendor, dev.idProduct, sernum, ifcount,
-                         description))
-        return list(devices)
+            devices.append((dev.idVendor, dev.idProduct, sernum, ifcount,
+                            description))
+        return devices
 
     @classmethod
     def flush_cache(cls):

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -367,8 +367,8 @@ class UsbTools:
                              'No USB-Serial device has been detected')
         if idx is None:
             if len(candidates) > 1:
-                raise UsbToolsError('%d USB devices match URL' %
-                                    len(candidates))
+                raise UsbToolsError('%d USB devices match URL %s' %
+                                        (len(candidates), urlstr))
             idx = 0
         try:
             vendor, product, ifport, ifcount, description = \


### PR DESCRIPTION
The first two patches are minor cleanups, while patches 3 and 4 prepare the code base for allowing specific USB devices to be passed into the API. Finally, patches 5 and 6 implement support for passing USB devices directly into the FTDI API. This is all done optionally, so all existing users should remain functional.

There are also a couple of documentation additions that demonstrate how to use USB devices directly with FTDI objects.

Thierry