### PR TITLE
ftdi: Fix divisor calculation for _set_frequency()

### DIFF
--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -1604,14 +1604,16 @@ class Ftdi:
 
         # Calculate base speed clock divider
         divcode = Ftdi.ENABLE_CLK_DIV5
-        divisor = max(0, min(0xFFFF, int((Ftdi.BUS_CLOCK_BASE+frequency/2)/frequency)-1))
+        divisor = int((Ftdi.BUS_CLOCK_BASE+frequency/2)/frequency)-1
+        divisor = max(0, min(0xFFFF, divisor))
         actual_freq = Ftdi.BUS_CLOCK_BASE/(divisor+1)
         error = (actual_freq/frequency)-1
 
         # Should we use high speed clock available in H series?
         if self.is_H_series:
             # Calculate high speed clock divider
-            divisor_hs = max(0, min(0xFFFF, int((Ftdi.BUS_CLOCK_HIGH+frequency/2)/frequency)-1))
+            divisor_hs = int((Ftdi.BUS_CLOCK_HIGH+frequency/2)/frequency)-1
+            divisor_hs = max(0, min(0xFFFF, divisor_hs))
             actual_freq_hs = Ftdi.BUS_CLOCK_HIGH/(divisor_hs+1)
             error_hs = (actual_freq_hs/frequency)-1
             # Enable if closer to desired frequency (percentually)
@@ -1632,7 +1634,8 @@ class Ftdi:
         self.validate_mpsse()
         # Drain input buffer
         self.purge_rx_buffer()
-        self.log.debug('Bus frequency: %.6f MHz (error: %+.1f %%)', (actual_freq/1E6), error*100)
+        self.log.debug('Bus frequency: %.6f MHz (error: %+.1f %%)',
+                        (actual_freq/1E6), error*100)
         return actual_freq
 
     def __get_timeouts(self):

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -1614,15 +1614,12 @@ class Ftdi:
             divisor_hs = max(0, min(0xFFFF, int((Ftdi.BUS_CLOCK_HIGH+frequency/2)/frequency)-1))
             actual_freq_hs = Ftdi.BUS_CLOCK_HIGH/(divisor_hs+1)
             error_hs = (actual_freq_hs/frequency)-1
-            #self.log.debug('divisor %i, divisor_hs %i', divisor, divisor_hs)
-            #self.log.debug('error %+.3f, error_hs %+.3f', error*100, error_hs*100)
             # Enable if closer to desired frequency (percentually)
             if abs(error_hs) < abs(error):
                 divcode = Ftdi.DISABLE_CLK_DIV5
                 divisor = divisor_hs
                 actual_freq = actual_freq_hs
                 error = error_hs
-                #self.log.debug('Using high speed clock!')
 
         # FTDI expects little endian
         if self.is_H_series:


### PR DESCRIPTION
The current frequency calculation has some issues which are fixed by this pull request:

- When desired frequency is below base frequency (6 MHz), high speed clock mode (30 Mhz) is always disabled, leading to coarse frequency selection and inability to select frequencies like: 5 MHz, 4.3 MHz, 2.5 MHz etc.. The proposed change will select the optimal clock mode and divisor to minimize the percentile error from the desired frequency.
- Formula for divisor will now round to nearest instead of always rounding up.
- Divisor can no longer overflow 0xFFFF for extremely low frequencies (below ~92 Hz).
- Calculation of actual_freq corrected to be according to FTDI AN135 (minor).