### PR TITLE
Added some more info on fixing the access denied issue for MacOS

### DIFF
--- a/pyftdi/doc/defs.rst
+++ b/pyftdi/doc/defs.rst
@@ -23,4 +23,5 @@
 .. _Zadig: http://zadig.akeo.ie/
 .. _FTDI macOS guide: http://www.ftdichip.com/Support/Documents/AppNotes/AN_134_FTDI_Drivers_Installation_Guide_for_MAC_OSX.pdf
 .. _Libusb issue on macOs: https://github.com/libusb/libusb/commit/5e45e0741daee4fa295c6cc977edfb986c872152
-
+.. _handy helper for macOS 10.11: https://www.ftdichip.com/Drivers/D2XX.htm
+.. _Installing D2xx drivers on macOS: https://youtu.be/Ir2PVz1870E

--- a/pyftdi/doc/troubleshooting.rst
+++ b/pyftdi/doc/troubleshooting.rst
@@ -50,6 +50,9 @@ The system may already be using the device.
   Please note that the system automatically reloads the driver, so it may be
   useful to move the kernel extension so that the system never loads it.
 
+  FTDI provides a `handy helper for macOS 10.11`_ and later, to prevent automatic claiming of the device as a serial port.
+  They have also included a `Installing D2xx drivers on macOS`_ video, on how to install the drivers and the helper.
+
 * On Linux: it may indicate a missing or invalid udev configuration. See
   the :doc:`installation` section.
 


### PR DESCRIPTION
I could not get the kextunload to work on macOS 10.14. The error "Error: Access denied (insufficient permissions)" still appeared. 

After a lot of searching, I could manage to solve the problem by installing the FTDI helper. I think this would be a nice addition to the documentation, as others are facing the same issue (#114 -> I've also upgraded my Mac from previous macOS versions).