### PR TITLE
Add option to not automatically sync/flush command queue when changing Tap controller state.

### DIFF
--- a/pyftdi/jtag.py
+++ b/pyftdi/jtag.py
@@ -452,14 +452,16 @@ class JtagEngine:
 
     def change_state(self, statename, sync=True):
         """Advance the TAP controller to the defined state"""
-        # find the state machine path to move to the new instruction
-        path = self._sm.find_path(statename)
-        # convert the path into an event sequence
-        events = self._sm.get_events(path)
-        # update the remote device tap controller
-        self._ctrl.write_tms(events,sync)
-        # update the current state machine's state
-        self._sm.handle_events(events)
+        # do nothing if we are at the target state already
+        if str(statename) != str(self._sm.state()):
+            # find the state machine path to move to the new instruction
+            path = self._sm.find_path(statename)
+            # convert the path into an event sequence
+            events = self._sm.get_events(path)
+            # update the remote device tap controller
+            self._ctrl.write_tms(events,sync)
+            # update the current state machine's state
+            self._sm.handle_events(events)
 
     def go_idle(self):
         """Change the current TAP controller to the IDLE state"""


### PR DESCRIPTION
Calls to Ftdi.write_data() may be time consuming (up to several milli seconds). For JTAG we like to queue multiple TAP controller sequences (Shift multiple IR or DR) before sending them to the FTDI in a single bulk transfer.

By default the JtagController.write_tms() syncs/flushes the command stack. This results in at least one call to sync() if DR or IR are updated which leads to unacceptable run-time if multiple IR/DR updates are required in a row.

I added an optional 'sync' paramter to JtagController.write_tms() to not flush the command stack if set to False. Also added this option to all calling functions.

By default JtagEngine.change_state() will result in an Exception (JtagController.write_tms() -> JtagError('Invalid TMS length') )  if we want to change to the state we are currently at. Modified JtagEngine.change_state() to fix this.