### PR TITLE
Removed assumption that USB device description

### DIFF
--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -146,15 +146,11 @@ class UsbTools:
         """
         cls.Lock.acquire()
         try:
-            if devdesc.index or devdesc.sn or devdesc.description:
+            if devdesc.index or devdesc.sn:
                 dev = None
                 if not devdesc.vid:
                     raise ValueError('Vendor identifier is required')
                 devs = cls._find_devices(devdesc.vid, devdesc.pid)
-                if devdesc.description:
-                    devs = [dev for dev in devs if
-                            UsbTools.get_string(dev, dev.iProduct) ==
-                            devdesc.description]
                 if devdesc.sn:
                     devs = [dev for dev in devs if
                             UsbTools.get_string(dev, dev.iSerialNumber) ==


### PR DESCRIPTION
On my  FT-MOD-4232HUB, the idProduct does not match the USB description (which is all FFs).  In the code, it makes sense to filter by serial number but assuming devdesc.description is ALWAYS equal to idProduct is not a safe bet.