### PR TITLE
UART: pyterm.py: Full functionality for Windows

### DIFF
--- a/pyftdi/bin/pyterm.py
+++ b/pyftdi/bin/pyterm.py
@@ -61,124 +61,15 @@ from pyftdi.misc import to_bps, add_custom_devices
 if MSWIN:
     import msvcrt
     from subprocess import call
+    from pyterm_winkeys import WinEscapes
 else:
     msvcrt = None
     call = None
+    WinEscapes = None
 
 #pylint: enable-msg=invalid-name
 #pylint: enable-msg=import-error
 
-"""
-Windows function key scan codes to ANSI escape code dictionary:
-
-Pause/Break, Ctrl+Alt+Del, Ctrl+Alt+arrows not mapable
-Input: ordinal of char from msvcrt.getch()
-Output: bytes string of ANSI escape sequence for linux/xterm
-        numerical used over linux specifics for Home and End
-        VT or CSI escape sequences used when linux has no sequence
-        something unique for keys without an escape function
-\x1b == Escape key
-"""
-
-if MSWIN:
-    winfnkeys = {
-        #Ctrl + Alt + Backspace
-        14:     b'\x1b^H',
-        #Ctrl + Alt + Enter
-        28:     b'\x1b\r',
-        # Pause/Break
-        29:     b'\x1c',
-        # Arrows
-        72:     b'\x1b[A',
-        80:     b'\x1b[B',
-        77:     b'\x1b[C',
-        75:     b'\x1b[D',
-        # Arrows (Alt)
-        152:    b'\x1b[1;3A',
-        160:    b'\x1b[1;3B',
-        157:    b'\x1b[1;3C',
-        155:    b'\x1b[1;3D',
-        # Arrows (Ctrl)
-        141:    b'\x1b[1;5A',
-        145:    b'\x1b[1;5B',
-        116:    b'\x1b[1;5C',
-        115:    b'\x1b[1;5D',
-        #Ctrl + Tab
-        148:    b'\x1b[2J',
-        # Cursor (Home, Ins, Del...)
-        71:     b'\x1b[1~',
-        82:     b'\x1b[2~',
-        83:     b'\x1b[3~',
-        79:     b'\x1b[4~',
-        73:     b'\x1b[5~',
-        81:     b'\x1b[6~',
-        # Cursor + Alt
-        151:    b'\x1b[1;3~',
-        162:    b'\x1b[2;3~',
-        163:    b'\x1b[3;3~',
-        159:    b'\x1b[4;3~',
-        153:    b'\x1b[5;3~',
-        161:    b'\x1b[6;3~',
-        # Cursor + Ctrl (xterm)
-        119:    b'\x1b[1;5H',
-        146:    b'\x1b[2;5~',
-        147:    b'\x1b[3;5~',
-        117:    b'\x1b[1;5F',
-        134:    b'\x1b[5;5~',
-        118:    b'\x1b[6;5~',
-        # Function Keys (F1 - F12)
-        59:     b'\x1b[11~',
-        60:     b'\x1b[12~',
-        61:     b'\x1b[13~',
-        62:     b'\x1b[14~',
-        63:     b'\x1b[15~',
-        64:     b'\x1b[17~',
-        65:     b'\x1b[18~',
-        66:     b'\x1b[19~',
-        67:     b'\x1b[20~',
-        68:     b'\x1b[21~',
-        133:    b'\x1b[23~',
-        134:    b'\x1b[24~',
-        # Function Keys + Shift (F11 - F22)
-        84:     b'\x1b[23;2~',
-        85:     b'\x1b[24;2~',
-        86:     b'\x1b[25~',
-        87:     b'\x1b[26~',
-        88:     b'\x1b[28~',
-        89:     b'\x1b[29~',
-        90:     b'\x1b[31~',
-        91:     b'\x1b[32~',
-        92:     b'\x1b[33~',
-        93:     b'\x1b[34~',
-        135:    b'\x1b[20;2~',
-        136:    b'\x1b[21;2~',
-        # Function Keys + Ctrl (xterm)
-        94:     b'\x1bOP',
-        95:     b'\x1bOQ',
-        96:     b'\x1bOR',
-        97:     b'\x1bOS',
-        98:     b'\x1b[15;2~',
-        99:     b'\x1b[17;2~',
-        100:    b'\x1b[18;2~',
-        101:    b'\x1b[19;2~',
-        102:    b'\x1b[20;3~',
-        103:    b'\x1b[21;3~',
-        137:    b'\x1b[23;3~',
-        138:    b'\x1b[24;3~',
-        # Function Keys + Alt (xterm)
-        104:    b'\x1b[11;5~',
-        105:    b'\x1b[12;5~',
-        106:    b'\x1b[13;5~',
-        107:    b'\x1b[14;5~',
-        108:    b'\x1b[15;5~',
-        109:    b'\x1b[17;5~',
-        110:    b'\x1b[18;5~',
-        111:    b'\x1b[19;5~',
-        112:    b'\x1b[20;5~',
-        113:    b'\x1b[21;5~',
-        139:    b'\x1b[23;5~',
-        140:    b'\x1b[24;5~',
-    }
 
 class MiniTerm:
     """A mini serial terminal to demonstrate pyserial extensions"""
@@ -306,7 +197,7 @@ class MiniTerm:
                 if MSWIN:
                     if ord(char) in (0, 224):
                         char = getkey()
-                        self._port.write(winfnkeys[ord(char)])
+                        self._port.write(WinEscapes().getch_to_escape(char))
                         continue
                     if ord(char) == 0x3:    # Ctrl+C
                         raise KeyboardInterrupt('Ctrl-C break')

--- a/pyftdi/bin/pyterm_winkeys.py
+++ b/pyftdi/bin/pyterm_winkeys.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""Simple Python serial terminal - Windows getch().msvcrt key scan code to ANSI escape code dictionary:
+"""
+
+# Copyright (c) 2010-2020, Emmanuel Blot <emmanuel.blot@free.fr>
+# Copyright (c) 2016, Emmanuel Bouaziz <ebouaziz@free.fr>
+# Copyright (c) 2020, Michael Pratt <mpratt51@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Neotion nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL NEOTION BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Pause/Break, Ctrl+Alt+Del, Ctrl+Alt+arrows not mapable
+Input: ordinal of char from msvcrt.getch()
+Output: bytes string of ANSI escape sequence for linux/xterm
+        numerical used over linux specifics for Home and End
+        VT or CSI escape sequences used when linux has no sequence
+        something unique for keys without an escape function
+\x1b == Escape key
+"""
+
+class WinEscapes:
+    def __init__(self):
+        self.winfnkeys = {
+            #Ctrl + Alt + Backspace
+            14:     b'\x1b^H',
+            #Ctrl + Alt + Enter
+            28:     b'\x1b\r',
+            # Pause/Break
+            29:     b'\x1c',
+            # Arrows
+            72:     b'\x1b[A',
+            80:     b'\x1b[B',
+            77:     b'\x1b[C',
+            75:     b'\x1b[D',
+            # Arrows (Alt)
+            152:    b'\x1b[1;3A',
+            160:    b'\x1b[1;3B',
+            157:    b'\x1b[1;3C',
+            155:    b'\x1b[1;3D',
+            # Arrows (Ctrl)
+            141:    b'\x1b[1;5A',
+            145:    b'\x1b[1;5B',
+            116:    b'\x1b[1;5C',
+            115:    b'\x1b[1;5D',
+            #Ctrl + Tab
+            148:    b'\x1b[2J',
+            # Cursor (Home, Ins, Del...)
+            71:     b'\x1b[1~',
+            82:     b'\x1b[2~',
+            83:     b'\x1b[3~',
+            79:     b'\x1b[4~',
+            73:     b'\x1b[5~',
+            81:     b'\x1b[6~',
+            # Cursor + Alt
+            151:    b'\x1b[1;3~',
+            162:    b'\x1b[2;3~',
+            163:    b'\x1b[3;3~',
+            159:    b'\x1b[4;3~',
+            153:    b'\x1b[5;3~',
+            161:    b'\x1b[6;3~',
+            # Cursor + Ctrl (xterm)
+            119:    b'\x1b[1;5H',
+            146:    b'\x1b[2;5~',
+            147:    b'\x1b[3;5~',
+            117:    b'\x1b[1;5F',
+            134:    b'\x1b[5;5~',
+            118:    b'\x1b[6;5~',
+            # Function Keys (F1 - F12)
+            59:     b'\x1b[11~',
+            60:     b'\x1b[12~',
+            61:     b'\x1b[13~',
+            62:     b'\x1b[14~',
+            63:     b'\x1b[15~',
+            64:     b'\x1b[17~',
+            65:     b'\x1b[18~',
+            66:     b'\x1b[19~',
+            67:     b'\x1b[20~',
+            68:     b'\x1b[21~',
+            133:    b'\x1b[23~',
+            134:    b'\x1b[24~',
+            # Function Keys + Shift (F11 - F22)
+            84:     b'\x1b[23;2~',
+            85:     b'\x1b[24;2~',
+            86:     b'\x1b[25~',
+            87:     b'\x1b[26~',
+            88:     b'\x1b[28~',
+            89:     b'\x1b[29~',
+            90:     b'\x1b[31~',
+            91:     b'\x1b[32~',
+            92:     b'\x1b[33~',
+            93:     b'\x1b[34~',
+            135:    b'\x1b[20;2~',
+            136:    b'\x1b[21;2~',
+            # Function Keys + Ctrl (xterm)
+            94:     b'\x1bOP',
+            95:     b'\x1bOQ',
+            96:     b'\x1bOR',
+            97:     b'\x1bOS',
+            98:     b'\x1b[15;2~',
+            99:     b'\x1b[17;2~',
+            100:    b'\x1b[18;2~',
+            101:    b'\x1b[19;2~',
+            102:    b'\x1b[20;3~',
+            103:    b'\x1b[21;3~',
+            137:    b'\x1b[23;3~',
+            138:    b'\x1b[24;3~',
+            # Function Keys + Alt (xterm)
+            104:    b'\x1b[11;5~',
+            105:    b'\x1b[12;5~',
+            106:    b'\x1b[13;5~',
+            107:    b'\x1b[14;5~',
+            108:    b'\x1b[15;5~',
+            109:    b'\x1b[17;5~',
+            110:    b'\x1b[18;5~',
+            111:    b'\x1b[19;5~',
+            112:    b'\x1b[20;5~',
+            113:    b'\x1b[21;5~',
+            139:    b'\x1b[23;5~',
+            140:    b'\x1b[24;5~',
+        }
+
+    def getch_to_escape(self, char):
+        return self.winfnkeys[ord(char)]


### PR DESCRIPTION
Reverses commit fa951f8f82c5d03c81cdc7d106288efee4f9515e

Provides actual support for "fullmode" and normal mode in Windows

Changes:

- workaround using subprocess module to force terminal to process ANSI escape sequences
- windows keyboard scan code to escape sequence dictionary
	msvcrt.getch() gathers raw keyboard codes for function keys, unprocessed by kernel
- cleanup of if statements

Tested with:

Windows 10
Python 3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)] on win32
a router at default baud rate

Signed-off-by: Michael Pratt <mpratt51@gmail.com>