### PR TITLE
Add support for integer serial number in device URL

### DIFF
--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -375,7 +375,9 @@ class Ftdi:
     def create_from_url(cls, url: str) -> 'Ftdi':
         """Create an Ftdi instance from an URL
 
-           URL scheme: ftdi://[vendor[:product[:index|:serial]]]/interface
+           URL scheme: ftdi://[vendor[:product[:index]]]/interface
+           URL scheme: ftdi://[vendor[:product[::serial]]]/interface
+           URL scheme: ftdi://[vendor[:product[:bus:address]]]/interface
 
            :param url: FTDI device selector
            :return: a fresh, open Ftdi instance

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -409,7 +409,7 @@ class UsbTools:
         bus = None
         address = None
         locators = specifiers[2:]
-        if len(locators) > 1:
+        if len(locators) > 1 and locators[0]:
             try:
                 bus = int(locators[0], 16)
                 address = int(locators[1], 16)
@@ -427,6 +427,8 @@ class UsbTools:
                         idx = devidx-1
                 except ValueError:
                     sernum = locators[0]
+            if locators and len(locators) > 1:
+                sernum = locators[1]
         candidates = []
         vendors = [vendor] if vendor else set(vdict.values())
         vps = set()


### PR DESCRIPTION
How about leaving specifier[2] as it is now (serial or device number), but add support for specifier[3] being serial number only. I'd open it with `bitbang.open_bitbang_from_url("ftdi://vid:pid::0025/1")` instead.

Resolved #209 