### PR TITLE
Fix #205 - I2C stop violation

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -969,7 +969,7 @@ class I2cController:
 
     @property
     def _stop(self) -> Tuple[int]:
-        return self._clk_lo_data_hi * self._ck_hd_sta + \
+        return self._clk_lo_data_lo * self._ck_hd_sta + \
                self._data_lo * self._ck_su_sto + \
                self._idle * self._ck_idle
 


### PR DESCRIPTION
Delay the SCL transition to correctly catch the SDA low->high transition.

