### PR TITLE
Fix I2C Start Violation, Fix I2C Stop Violation, Fix I2C timing > 100kHz, Allow all addresses

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -358,7 +358,9 @@ class I2cController:
     SDA_I_BIT = 0x04  #AD2
     SCL_FB_BIT = 0x80  #AD7
     PAYLOAD_MAX_LENGTH = 0xFF00  # 16 bits max (- spare for control)
-    HIGHEST_I2C_ADDRESS = 0x78
+    HIGHEST_I2C_ADDRESS = 0x7F  # slave addresses over 0x78 not allowed, but:
+                                # there is no reason to prevent the ftdi
+                                # from working with slaves there
     DEFAULT_BUS_FREQUENCY = 100000.0
     HIGH_BUS_FREQUENCY = 400000.0
     RETRY_COUNT = 3
@@ -442,9 +444,9 @@ class I2cController:
         if frequency <= 100E3:
             timings = self.I2C_100K
         elif frequency <= 400E3:
-            timings = self.I2C_100K
+            timings = self.I2C_400K
         else:
-            timings = self.I2C_100K
+            timings = self.I2C_1M
         if 'clockstretching' in kwargs:
             clkstrch = bool(kwargs['clockstretching'])
             del kwargs['clockstretching']
@@ -949,7 +951,8 @@ class I2cController:
 
     @property
     def _stop(self) -> Tuple[int]:
-        return self._clk_lo_data_lo * self._ck_hd_sta + \
+        return self._clk_lo_data_hi * self._ck_hd_sta + \
+               self._clk_lo_data_lo * self._ck_hd_sta + \
                self._data_lo * self._ck_su_sto + \
                self._idle * self._ck_idle
 

--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -997,7 +997,8 @@ class I2cController:
         if i2caddress is None:
             return
         self.log.debug('   prolog 0x%x', i2caddress >> 1)
-        cmd = bytearray(self._idle)
+        #cmd = bytearray(self._idle) #original
+        cmd = bytearray(self._idle * self._ck_delay) #new
         cmd.extend(self._start)
         cmd.extend(self._write_byte)
         cmd.append(i2caddress)

--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -997,8 +997,7 @@ class I2cController:
         if i2caddress is None:
             return
         self.log.debug('   prolog 0x%x', i2caddress >> 1)
-        #cmd = bytearray(self._idle) #original
-        cmd = bytearray(self._idle * self._ck_delay) #new
+        cmd = bytearray(self._idle * self._ck_delay)  # use delay on set clk idle
         cmd.extend(self._start)
         cmd.extend(self._write_byte)
         cmd.append(i2caddress)


### PR DESCRIPTION
Fix I2C Start Violation, 
The prologue was incorrect when used with clock stretching or relax=False.  In this case the clock was LOW prior to the start or repeated start and so the _idle state needed a clock delay to avoid data and clock moving together.
The master branch start is:
![image](https://user-images.githubusercontent.com/72464096/102137389-c33b7600-3e28-11eb-8405-49e97e38481f.png)

the pull request branch with change to prologue is:
![image](https://user-images.githubusercontent.com/72464096/102137424-cfbfce80-3e28-11eb-82d6-1899e2dc4695.png)

Fix I2C Stop Violation, 
Fix for #205 merged in September wasn't quite enough. Clock and data transitioned on the same edge if clock was low prior to the stop, such as in relax=False or clock stretching.
the master branch is:
![image](https://user-images.githubusercontent.com/72464096/102137541-fbdb4f80-3e28-11eb-8c51-0091eb30a2b7.png)

the pull request brange with change to _stop is:
![image](https://user-images.githubusercontent.com/72464096/102137578-0ac20200-3e29-11eb-8b21-775e6d948a45.png)

The I2C spec v6.0 shows this:
![image](https://user-images.githubusercontent.com/72464096/102137718-44930880-3e29-11eb-8831-bc65e5f43a9d.png)

Fix I2C timing > 100kHz, 
Implemented the finding in #203 and my system now works A-OK at all speeds.

Allow all addresses
The driver was technically correct in that it would not allow a slave above 0x78 to be found, however some naughty slaves can go to illegal addresses.  Since these Ftdi devices are probably going to be used in a development environment (as mine is) why not allow finding slaves at illegal addresses up to 0x7F.  Then it's up to the program using the driver to obey the rules, much like a speed limit doesn't stop you from driving too fast.  The change should be harmless to anyone using it for address search.  In my system it is absolutely necessary that the full table be searchable.

Combined all of these changes also address #215.

My setup is a custom I2C slave working with C232HM-DDHSL-0 dongle (digikey) with a diode connected to allow clock stretching as per this image:
![image](https://user-images.githubusercontent.com/72464096/102138726-cd5e7400-3e2a-11eb-8bc9-7d626c3586c6.png)

