### PR TITLE
spi.py:fix spi model_0 for read. data shift at negedge, sample at posedge.

### DIFF
--- a/pyftdi/spi.py
+++ b/pyftdi/spi.py
@@ -819,18 +819,18 @@ class SpiController:
                 cmd.extend(write_cmd)
         if readlen:
             if not droptail:
-                rcmd = (Ftdi.READ_BYTES_NVE_MSB if not cpol else
+                rcmd = (Ftdi.READ_BYTES_NVE_MSB if cpol else
                         Ftdi.READ_BYTES_PVE_MSB)
                 read_cmd = spack('<BH', rcmd, readlen-1)
                 cmd.extend(read_cmd)
             else:
                 bytelen = readlen-1
                 if bytelen:
-                    rcmd = (Ftdi.READ_BYTES_NVE_MSB if not cpol else
+                    rcmd = (Ftdi.READ_BYTES_NVE_MSB if cpol else
                             Ftdi.READ_BYTES_PVE_MSB)
                     read_cmd = spack('<BH', rcmd, bytelen-1)
                     cmd.extend(read_cmd)
-                rcmd = (Ftdi.READ_BITS_NVE_MSB if not cpol else
+                rcmd = (Ftdi.READ_BITS_NVE_MSB if cpol else
                         Ftdi.READ_BITS_PVE_MSB)
                 read_cmd = spack('<BB', rcmd, 7-droptail)
                 cmd.extend(read_cmd)


### PR DESCRIPTION
We noticed with CPOL=0 and CPHA=0 this did not work. With CPHA=0 we should be sampling on the positive edge, not the negative. Perhaps CPHA needs to be factored in here, too. In the meantime reversing the polarity of this check works.
![1920px-SPI_timing_diagram2 svg](https://user-images.githubusercontent.com/41956199/113794853-d0d98a80-978e-11eb-87b9-f4c6da1bbbd5.png)
