### PR TITLE
Update troubleshooting doc

### DIFF
--- a/pyftdi/doc/troubleshooting.rst
+++ b/pyftdi/doc/troubleshooting.rst
@@ -38,6 +38,12 @@ libusb native library cannot be loaded. Try helping the dynamic loader:
   where ``<path>`` is the directory containing the ``libusb-1.*.dylib``
   library file
 
+* On Windows, if this happens while using an exe created by pyinstaller: ``copy C:\Windows\System32\libusb0.dll <path>``
+
+  where ``<path>`` is the directory containing the executable created
+  by pyinstaller. This assumes you have installed libusb (using a tool
+  like Zadig) as referenced in the installation guide for Windows.
+
 
 "Error: Access denied (insufficient permissions)"
 `````````````````````````````````````````````````


### PR DESCRIPTION
Adds a potential solution for the "No backend available" error on windows when using pyinstaller.

Issue discussed further in https://github.com/eblot/pyftdi/issues/29