### PR TITLE
spi: support read length > SpiController.PAYLOAD_MAX_LENGTH

### DIFF
--- a/pyftdi/spi.py
+++ b/pyftdi/spi.py
@@ -773,8 +773,6 @@ class SpiController:
             raise SpiIOError("FTDI controller not initialized")
         if len(out) > SpiController.PAYLOAD_MAX_LENGTH:
             raise SpiIOError("Output payload is too large")
-        if readlen > SpiController.PAYLOAD_MAX_LENGTH:
-            raise SpiIOError("Input payload is too large")
         if cpha:
             # to enable CPHA, we need to use a workaround with FTDI device,
             # that is enable 3-phase clocking (which is usually dedicated to
@@ -830,16 +828,28 @@ class SpiController:
                 cmd.extend(write_cmd)
         if readlen:
             if not droptail:
+                n = readlen // SpiController.PAYLOAD_MAX_LENGTH
+                r = readlen % SpiController.PAYLOAD_MAX_LENGTH
+
                 rcmd = (Ftdi.READ_BYTES_NVE_MSB if not cpol else
                         Ftdi.READ_BYTES_PVE_MSB)
-                read_cmd = spack('<BH', rcmd, readlen-1)
+                for i in range(n):
+                    read_cmd = spack('<BH', rcmd, SpiController.PAYLOAD_MAX_LENGTH-1)
+                    cmd.extend(read_cmd)
+                read_cmd = spack('<BH', rcmd, r-1)
                 cmd.extend(read_cmd)
             else:
                 bytelen = readlen-1
                 if bytelen:
+                    n = bytelen // SpiController.PAYLOAD_MAX_LENGTH
+                    r = bytelen % SpiController.PAYLOAD_MAX_LENGTH
+
                     rcmd = (Ftdi.READ_BYTES_NVE_MSB if not cpol else
                             Ftdi.READ_BYTES_PVE_MSB)
-                    read_cmd = spack('<BH', rcmd, bytelen-1)
+                    for i in range(n):
+                        read_cmd = spack('<BH', rcmd, SpiController.PAYLOAD_MAX_LENGTH-1)
+                        cmd.extend(read_cmd)
+                    read_cmd = spack('<BH', rcmd, r-1)
                     cmd.extend(read_cmd)
                 rcmd = (Ftdi.READ_BITS_NVE_MSB if not cpol else
                         Ftdi.READ_BITS_PVE_MSB)


### PR DESCRIPTION
support read length > SpiController.PAYLOAD_MAX_LENGTH by consecutive read commands to minimize timing gap 