### PR TITLE
i2C GPIO fix and SPI GPIO fix for _gpio_mask

### DIFF
--- a/pyftdi/__init__.py
+++ b/pyftdi/__init__.py
@@ -6,7 +6,7 @@
 
 #pylint: disable-msg=missing-docstring
 
-__version__ = '0.53.3'
+__version__ = '0.53.4'
 __title__ = 'PyFtdi'
 __description__ = 'FTDI device driver (pure Python)'
 __uri__ = 'http://github.com/eblot/pyftdi'


### PR DESCRIPTION
fixes issues in #233 which were followed up in #270 and  #260 (260 closed for being a sloppy commit)

The _gpio_mask was being reduced every time a pin was set to tri-state.  Once put into tri-state the pin could not be written, or removed from tri-state back to active because the mask test forbid it as 'non existant'

with the changes in this branch the gpio_mask becomes something setup for the ftdi device connected to and it remains static.
Some enhancements were made to allow use of pins as open-drain by setting driving state low and using tri-state as the state switch.

Perhaps a future branch should add the ability to read the i2c/spi pin states to check for common hardware issues (floating, stuck high, stuck low etc).

In this branch I worked on the I2C and SPI module and use of GPIO.
_gpio_mask was made a permanent fixture (after all they don't change)
_gpio_last was added to keep track of users last state for the pins
immediate was added to set_direction so that a change of in to out or out to in would take effect immediately (new default behavior)
with_input added to write to allow "writes" to gpio's set as inputs, which is useful for open-drain behavior when combined with gpio_last (new default behavior). This suppresses an error message that used to occur, but since no reasonably functional code would be looking for an error it should work for everyone.
This version should be backwards compatible with any existing code.
Also added the reset/freeze options for opening/closing the device in terminate() 
Tested with C232HM-EDHSL-0
