### PR TITLE
Fake tri-state: Move SDA=output after ACK to before I2C write to avoid momentary shorts after ACK during I2C reads

### DIFF
--- a/pyftdi/gpio.py
+++ b/pyftdi/gpio.py
@@ -481,7 +481,7 @@ class GpioMpsseController(GpioBaseController):
         self._frequency = self._ftdi.set_frequency(float(frequency))
 
     def _update_direction(self) -> None:
-        # nothing to do in MPSSE mode, as direction is udpated with each
+        # nothing to do in MPSSE mode, as direction is updated with each
         # GPIO command
         pass
 


### PR DESCRIPTION
After the master sends the request to read from a slave and after the ACK from the slave, the _send_check_ack function ends with SDA being a HI output. During this period to when the master starts clocking in the data it wants to read, some slaves pull the SDA line low. This would short the SDA output to GND, causing it to draw its max current (16mA for the FT4232). This fix makes it so that if the next action after the ACK is a read, SDA remains as an input during this period of time.