### PR TITLE
Fix start address of CRC word (16 bit) when checking the remaining space for USB descriptor strings

### DIFF
--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -717,7 +717,7 @@ class FtdiEeprom:
             self._eeprom[s1_vstr_start:s1_vstr_start+len(stream)] = stream
         self._eeprom[dynpos:dynpos+len(stream)] = stream
         mtp = self._ftdi.device_version == 0x1000
-        crc_pos = 0x100 if mtp else self._size
+        crc_pos = ( 0x100 if mtp else self._size ) - 2
         rem = crc_pos - (dynpos + len(stream))
         if rem < 0:
             oversize = (-rem + 2) // 2


### PR DESCRIPTION
In eeprom.py:721 the calculation of the address where the CRC is stored in the EEPROM is fixed to be at either `0x9E` or `eeprom._size-2`. Without this fix the last two bytes of the `serial` string can be overwritten by the CRC without raising the exception `FtdiEepromError(...)` inline 725.