### PR TITLE
jtag: write_tms() should only sync() if should_read is true

### DIFF
--- a/pyftdi/jtag.py
+++ b/pyftdi/jtag.py
@@ -262,7 +262,8 @@ class JtagController:
         else:
             cmd = bytearray((Ftdi.WRITE_BITS_TMS_NVE, length-1, out.tobyte()))
         self._stack_cmd(cmd)
-        self.sync()
+        if should_read:
+            self.sync()
 
     def read(self, length: int) -> BitSequence:
         """Read out a sequence of bits from TDO."""


### PR DESCRIPTION
If write_tms() syncs without regard to should_read, the minimum period between writes to JTAG registers (e.g. the EXTEST register) is bounded by the round-trip USB delay. If write_tms() only syncs when the read data is required (i.e. should_read is true), then back to back writes to JTAG registers can occur at the full TCLK rate.

This is particularly important when external signals need to be precisely sequenced with JTAG commands (for example, applying an external programming voltage for blowing an eFuse).

Example before this change (programming voltage is applied for 3ms, when it only needs to be applied for 40us).  The total lifetime voltage application for an eFuse block is ~10ms, so this expends almost a third of that budget for blowing eFuses on a device, when it only needs to expend 1/250th of the lifetime voltage application budget if the JTAG write operations could operate back-to-back.

<img width="1687" alt="Screenshot 2022-11-09 at 9 40 07 am" src="https://user-images.githubusercontent.com/18667/200732791-049a08ef-077f-48fb-945d-f3ea1bfb8c18.png">

Example after this change (programming voltage is applied for the required 40us to blow the eFuse, because back to back JTAG write operations can proceed without USB round-trip delays).

<img width="1661" alt="Screenshot 2022-11-09 at 9 39 36 am" src="https://user-images.githubusercontent.com/18667/200732829-4b6d422a-0061-495c-a8a4-dd7191b03ef2.png">

write_tms() is called from six different functions in jtag.py:

1) in JtagController.reset(), write_tms() is called with should_read = False.   The reset() function has a sync argument which can force a sync() immediately after write_tms().  There is no reason that write_tms(should_read=False) should do an additional sync() here, so this change has no negative impact.

2) in JtagEngine.write_tms(), the should_read argument is passed through to JtagController.write_tms(), so this change has no negative impact.

3) in JtagEngine.change_state(), write_tms() is called with should_read = False.  After this, handle_events() is called, and does not depend upon reading from write_tms(), nor does it depend upon a sync() being called inside write_tms(), so this change has no negative impact.

4) in JtagEngine.shift_register(), write_tms() is called with should_read = False.  After this, read_from_buffer() is called and it in turn calls sync(), so this change has no negative impact (in fact it removes a superfluous sync() call).

5) in JtagEngine.shift_and_update_register(), write_tms() is called once with should_read = False, and then a second time explicitly with should_read = True.  After this, read_from_buffer() is called and it in turn calls sync(), so this change has no negative impact.

6) in JtagTool.detect_register_size(), write_tms() is called with should_read = False.  After this, shift_register() is called, which in turn calls read_from_buffer() and it in turn calls sync(), so this change has no negative impact (in fact it removes a superfluous sync() call).

