### PR TITLE
Support for FTDI ft4232ha added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Suported FTDI devices include:
   * FT232H (single port, clock up to 30 MHz)
   * FT2232H (dual port, clock up to 30 MHz)
   * FT4232H (quad port, clock up to 30 MHz)
+  * FT4232HA (quad port, clock up to 30 MHz)
 
 ## Features
 

--- a/pyftdi/doc/api/i2c.rst
+++ b/pyftdi/doc/api/i2c.rst
@@ -132,8 +132,8 @@ Fortunately, FT232H device is fitted with real open collector outputs, and
 PyFtdi always enable this mode on SCL and SDA lines when a FT232H device is
 used.
 
-Other FTDI devices such as FT2232H and FT4232H do not support open collector
-mode, and source current to SCL and SDA lines.
+Other FTDI devices such as FT2232H, FT4232H and FT4232HA do not support open
+collector mode, and source current to SCL and SDA lines.
 
 Clock streching
 ```````````````
@@ -143,7 +143,7 @@ clock mode designed for ARM devices. FTDI HW drives SCL on ``AD0`` (`BD0`), and
 samples the SCL line on : the 8\ :sup:`th` pin of a port ``AD7`` (``BD7``).
 
 When a FTDI device without an open collector capability is used (FT2232H,
-FT4232H) the current sourced from AD0 may prevent proper sampling of the SCL
+FT4232H, FT4232HA) the current sourced from AD0 may prevent proper sampling of the SCL
 line when the slave attempts to strech the clock. It is therefore recommended
 to add a low forward voltage drop diode to `AD0` to prevent AD0 to source
 current to the SCL bus. See the wiring section.
@@ -165,7 +165,7 @@ Use of PyFtdi_ should nevetherless carefully studied and is not recommended if
 you need to achieve medium to high speed write operations with a slave
 (relative to the I2C clock...). Dedicated I2C master such as FT4222H device is
 likely a better option, but is not currently supported with PyFtdi_ as it uses
-a different communication protocol. 
+a different communication protocol.
 
 .. _i2c_wiring:
 
@@ -187,5 +187,5 @@ Wiring
 *Fig.1*:
 
 * ``D1`` is only required when clock streching is used along with
-  FT2232H or FT4232H devices. It should not be fit with an FT232H.
+  FT2232H, FT4232H or FT4232HA devices. It should not be fit with an FT232H.
 * ``AD7`` may be used as a regular GPIO with clock stretching is not required.

--- a/pyftdi/doc/api/spi.rst
+++ b/pyftdi/doc/api/spi.rst
@@ -158,7 +158,7 @@ Application Node 114:
 
 Support for mode 1 and mode 3 is implemented with some workarounds, but
 generated signals may not be reliable: YMMV. It is only available with -H
-series (232H, 2232H, 4232H).
+series (232H, 2232H, 4232H, 4232HA).
 
 The 3-clock phase mode which has initially be designed to cope with |I2C|
 signalling is used to delay the data lines from the clock signals. A direct

--- a/pyftdi/doc/defs.rst
+++ b/pyftdi/doc/defs.rst
@@ -6,6 +6,7 @@
 .. _FT232H: http://www.ftdichip.com/Products/ICs/FT232H.htm
 .. _FT2232H: http://www.ftdichip.com/Products/ICs/FT2232H.html
 .. _FT4232H: http://www.ftdichip.com/Products/ICs/FT4232H.htm
+.. _FT4232HA: http://ftdichip.com/products/ft4232haq/
 .. _FTDI_Recovery: http://www.ftdichip.com/Support/Documents/AppNotes/AN_136%20Hi%20Speed%20Mini%20Module%20EEPROM%20Disaster%20Recovery.pdf
 .. _PyFtdi: https://www.github.com/eblot/pyftdi
 .. _PyFtdiTools: https://github.com/eblot/pyftdi/tree/master/pyftdi/bin

--- a/pyftdi/doc/features.rst
+++ b/pyftdi/doc/features.rst
@@ -39,7 +39,7 @@ Mode   CPol   CPha  Status
 =====  ===== ====== ====================================================
   0      0      0   Supported on all MPSSE devices
   1      0      1   Workaround available for on -H series
-  2      1      0   Supported on -H series (FT232H_/FT2232H_/FT4232H_)
+  2      1      0   Supported on -H series (FT232H_/FT2232H_/FT4232H_/FT4232HA_)
   3      1      1   Workaround available for on -H series
 =====  ===== ====== ====================================================
 
@@ -61,7 +61,7 @@ Note: FTDI*232* devices cannot be used as an SPI slave.
 |I2C| master
 ````````````
 
-Supported devices: FT232H_, FT2232H_, FT4232H_
+Supported devices: FT232H_, FT2232H_, FT4232H_, FT4232HA_
 
 For now, only 7-bit addresses are supported.
 

--- a/pyftdi/doc/gpio.rst
+++ b/pyftdi/doc/gpio.rst
@@ -76,7 +76,7 @@ the actual hardware, *i.e.* the FTDI model:
   `BDBUS/BCBUS`,
 * FT2232H features two ports, which are 16-bit wide each: `ADBUS/ACBUS` and
   `BDBUS/BCBUS`,
-* FT4232H features four ports, which are 8-bit wide each: `ADBUS`, `BDBUS`,
+* FT4232H/FT4232HA features four ports, which are 8-bit wide each: `ADBUS`, `BDBUS`,
   `CDBUS` and `DDBUS`,
 * FT230X features a single port, which is 4-bit wide,
 * FT231X feature a single port, which is 8-bit wide

--- a/pyftdi/doc/index.rst
+++ b/pyftdi/doc/index.rst
@@ -45,6 +45,7 @@ Supported FTDI devices include:
   * FT232H (single port, clock up to 30 MHz)
   * FT2232H (dual port, clock up to 30 MHz)
   * FT4232H (quad port, clock up to 30 MHz)
+  * FT4232HA (quad port, clock up to 30 MHz)
 
 Features
 --------

--- a/pyftdi/doc/installation.rst
+++ b/pyftdi/doc/installation.rst
@@ -38,6 +38,8 @@ configure `udev`, here is a typical setup:
     SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6014", GROUP="plugdev", MODE="0664"
     # FT230X/FT231X/FT234X
     SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6015", GROUP="plugdev", MODE="0664"
+    # FT4232HA
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6048", GROUP="plugdev", MODE="0664"
 
 .. note:: **Accessing FTDI devices with custom VID/PID**
 

--- a/pyftdi/doc/pinout.rst
+++ b/pyftdi/doc/pinout.rst
@@ -30,9 +30,9 @@ FTDI device pinout
           is bi-directional, two FTDI pins are required to provide the SDA
           feature, and they should be connected together and to the SDA |I2C|
           bus line. Pull-up resistors on SCK and SDA lines should be used.
-.. [#if2] FT232H_ does not support a secondary MPSSE port, only FT2232H_ and
-          FT4232H_ do. Note that FT4232H_ has 4 serial ports, but only the
-          first two interfaces are MPSSE-capable. C232HD cable only exposes
+.. [#if2] FT232H_ does not support a secondary MPSSE port, only FT2232H_,
+          FT4232H_ and FT4232HA_ do. Note that FT4232H_/FT4232HA_ has 4 serial ports,
+          but only the first two interfaces are MPSSE-capable. C232HD cable only exposes
           IF/1 (ADBUS).
 .. [#rck] In order to support I2C clock stretch mode, ADBUS7 should be
           connected to SCK. When clock stretching mode is not selected, ADBUS7

--- a/pyftdi/doc/urlscheme.rst
+++ b/pyftdi/doc/urlscheme.rst
@@ -27,7 +27,7 @@ where:
     ``0x6015``
   * Supported product aliases:
 
-    * ``232``, ``232r``, ``232h``, ``2232d``, ``2232h``, ``4232h``, ``230x``
+    * ``232``, ``232r``, ``232h``, ``2232d``, ``2232h``, ``4232h``, ``4232ha``, ``230x``
     * ``ft`` prefix for all aliases is also accepted, as for example ``ft232h``
 
 * ``serial``: the serial number as a string. This is the preferred method to

--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -70,6 +70,7 @@ class FtdiEeprom:
         0x0800: _PROPS(256, 0x1A, 0x9A, 0x18),   # FT4232H
         0x0900: _PROPS(256, 0x1A, 0xA0, 0x1e),   # FT232H
         0x1000: _PROPS(1024, 0x1A, 0xA0, None),  # FT230X/FT231X/FT234X
+        0x3600: _PROPS(256, 0x1A, 0x9A, 0x18),   # FT4232HA
     }
     """EEPROM properties."""
 
@@ -634,7 +635,7 @@ class FtdiEeprom:
                   the EEPROM content
            :param no_crc: do not compute EEPROM CRC. This should only be used
             to perform a full erasure of the EEPROM, as an attempt to recover
-            from a corrupted config. 
+            from a corrupted config.
 
            :return: True if some changes have been committed to the EEPROM
         """
@@ -778,7 +779,7 @@ class FtdiEeprom:
             crc_s1_start = self.mirror_sector - crc_size
             self._eeprom[crc_s1_start:crc_s1_start+crc_size] = spack('<H', crc)
 
-    def _compute_size(self, 
+    def _compute_size(self,
             eeprom: Union[bytes, bytearray]) -> Tuple[int, bool]:
         """
             :return: Tuple of:
@@ -937,7 +938,7 @@ class FtdiEeprom:
     def _set_group(self, group: int, control: str,
                    value: Union[str, int, bool], out: Optional[TextIO]) \
             -> None:
-        if self.device_version in (0x0700, 0x0800, 0x0900):
+        if self.device_version in (0x0700, 0x0800, 0x0900, 0x3600):
             self._set_group_x232h(group, control, value, out)
             return
         raise ValueError('Group not implemented for this device')
@@ -951,7 +952,7 @@ class FtdiEeprom:
 
     def _set_group_x232h(self, group: int, control: str, value: str,
                          out: Optional[TextIO]) -> None:
-        if self.device_version in (0x0700, 0x800):  # 2232H/4232H
+        if self.device_version in (0x0700, 0x800, 0x3600):  # 2232H/4232H/4232HA
             offset = 0x0c + group//2
             nibble = group & 1
         else:  # 232H
@@ -1121,7 +1122,7 @@ class FtdiEeprom:
             cfg['channel_%x_rs485' % (0xa+chix)] = bool(conf & (rs485 << chix))
 
     def _decode_x232h(self, cfg):
-        # common code for 2232h and 4232h
+        # common code for 2232h, 4232h, 4232ha
         cfg0, cfg1 = self._eeprom[0x00], self._eeprom[0x01]
         cfg['channel_a_driver'] = 'VCP' if (cfg0 & (1 << 3)) else 'D2XX'
         cfg['channel_b_driver'] = 'VCP' if (cfg1 & (1 << 3)) else 'D2XX'

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -81,6 +81,7 @@ class Ftdi:
             ('230x', 0x6015),
             ('231x', 0x6015),
             ('234x', 0x6015),
+            ('4232ha', 0x6048),
             ('ft232', 0x6001),
             ('ft232r', 0x6001),
             ('ft232h', 0x6014),
@@ -92,7 +93,8 @@ class Ftdi:
             ('ft4232h', 0x6011),
             ('ft230x', 0x6015),
             ('ft231x', 0x6015),
-            ('ft234x', 0x6015)))
+            ('ft234x', 0x6015),
+            ('ft4232ha', 0x6048)))
         }
     """Supported products, only FTDI officials ones.
        To add third parties and customized products, see
@@ -110,20 +112,22 @@ class Ftdi:
         0x0700: 'ft2232h',
         0x0800: 'ft4232h',
         0x0900: 'ft232h',
-        0x1000: 'ft-x'}
+        0x1000: 'ft-x',
+        0x3600: 'ft4232ha'}
     """Common names of FTDI supported devices."""
 
     # Note that the FTDI datasheets contradict themselves, so
     # the following values may not be the right ones...
     FIFO_SIZES = {
-        0x0200: (128, 128),    # FT232AM: TX: 128, RX: 128
-        0x0400: (128, 384),    # FT232BM: TX: 128, RX: 384
-        0x0500: (128, 384),    # FT2232C: TX: 128, RX: 384
-        0x0600: (256, 128),    # FT232R:  TX: 256, RX: 128
-        0x0700: (4096, 4096),  # FT2232H: TX: 4KiB, RX: 4KiB
-        0x0800: (2048, 2048),  # FT4232H: TX: 2KiB, RX: 2KiB
-        0x0900: (1024, 1024),  # FT232H:  TX: 1KiB, RX: 1KiB
-        0x1000: (512, 512),    # FT-X:    TX: 512, RX: 512
+        0x0200: (128, 128),    # FT232AM:   TX: 128, RX: 128
+        0x0400: (128, 384),    # FT232BM:   TX: 128, RX: 384
+        0x0500: (128, 384),    # FT2232C:   TX: 128, RX: 384
+        0x0600: (256, 128),    # FT232R:    TX: 256, RX: 128
+        0x0700: (4096, 4096),  # FT2232H:   TX: 4KiB, RX: 4KiB
+        0x0800: (2048, 2048),  # FT4232H:   TX: 2KiB, RX: 2KiB
+        0x0900: (1024, 1024),  # FT232H:    TX: 1KiB, RX: 1KiB
+        0x1000: (512, 512),    # FT-X:      TX: 512, RX: 512
+        0x3600: (2048, 2048),  # FT4232HA:  TX: 2KiB, RX: 2KiB
     }
     """FTDI chip internal FIFO sizes
 
@@ -508,8 +512,8 @@ class Ftdi:
            the USB device in random order. serial argument is more reliable
            selector and should always be prefered.
 
-           Some FTDI devices support several interfaces/ports (such as FT2232H
-           and FT4232H). The interface argument selects the FTDI port to use,
+           Some FTDI devices support several interfaces/ports (such as FT2232H,
+           FT4232H and FT4232HA). The interface argument selects the FTDI port to use,
            starting from 1 (not 0).
 
            :param int vendor: USB vendor id
@@ -654,8 +658,8 @@ class Ftdi:
            the USB device in random order. serial argument is more reliable
            selector and should always be prefered.
 
-           Some FTDI devices support several interfaces/ports (such as FT2232H
-           and FT4232H). The interface argument selects the FTDI port to use,
+           Some FTDI devices support several interfaces/ports (such as FT2232H,
+           FT4232H and FT4232HA). The interface argument selects the FTDI port to use,
            starting from 1 (not 0). Note that not all FTDI ports are MPSSE
            capable.
 
@@ -707,8 +711,8 @@ class Ftdi:
            the USB device in random order. serial argument is more reliable
            selector and should always be prefered.
 
-           Some FTDI devices support several interfaces/ports (such as FT2232H
-           and FT4232H). The interface argument selects the FTDI port to use,
+           Some FTDI devices support several interfaces/ports (such as FT2232H,
+           FT4232H and FT4232HA). The interface argument selects the FTDI port to use,
            starting from 1 (not 0). Note that not all FTDI ports are MPSSE
            capable.
 
@@ -945,7 +949,7 @@ class Ftdi:
         """
         if not self.is_connected:
             raise FtdiError('Device characteristics not yet known')
-        return self.device_version in (0x0500, 0x0700, 0x0800, 0x0900)
+        return self.device_version in (0x0500, 0x0700, 0x0800, 0x0900, 0x3600)
 
     @property
     def has_wide_port(self) -> bool:
@@ -1008,7 +1012,7 @@ class Ftdi:
         """
         if not self.is_connected:
             raise FtdiError('Device characteristics not yet known')
-        return self.device_version in (0x0700, 0x0800, 0x0900)
+        return self.device_version in (0x0700, 0x0800, 0x0900, 0x3600)
 
 
     @property
@@ -1028,6 +1032,8 @@ class Ftdi:
         if not self.has_mpsse:
             return False
         if self.device_version == 0x0800 and interface > 2:
+            return False
+        if self.device_version == 0x3600 and interface > 2:
             return False
         return True
 

--- a/pyftdi/tests/backend/ftdivirt.py
+++ b/pyftdi/tests/backend/ftdivirt.py
@@ -230,14 +230,15 @@ class VirtFtdiPort:
         SYNCFF = 0x40   # Single Channel Synchronous FIFO mode
 
     FIFO_SIZES = {
-        0x0200: (128, 128),    # FT232AM: TX: 128, RX: 128
-        0x0400: (128, 384),    # FT232BM: TX: 128, RX: 384
-        0x0500: (128, 384),    # FT2232C: TX: 128, RX: 384
-        0x0600: (256, 128),    # FT232R:  TX: 256, RX: 128
-        0x0700: (4096, 4096),  # FT2232H: TX: 4KiB, RX: 4KiB
-        0x0800: (2048, 2048),  # FT4232H: TX: 2KiB, RX: 2KiB
-        0x0900: (1024, 1024),  # FT232H:  TX: 1KiB, RX: 1KiB
-        0x1000: (512, 512),    # FT-X:    TX: 512, RX: 512
+        0x0200: (128, 128),    # FT232AM:   TX: 128, RX: 128
+        0x0400: (128, 384),    # FT232BM:   TX: 128, RX: 384
+        0x0500: (128, 384),    # FT2232C:   TX: 128, RX: 384
+        0x0600: (256, 128),    # FT232R:    TX: 256, RX: 128
+        0x0700: (4096, 4096),  # FT2232H:   TX: 4KiB, RX: 4KiB
+        0x0800: (2048, 2048),  # FT4232H:   TX: 2KiB, RX: 2KiB
+        0x0900: (1024, 1024),  # FT232H:    TX: 1KiB, RX: 1KiB
+        0x1000: (512, 512),    # FT-X:      TX: 512, RX: 512
+        0x3600: (2048, 2048),  # FT4232HA:  TX: 2KiB, RX: 2KiB
     }
     """FTDI chip internal FIFO sizes.
 
@@ -252,7 +253,8 @@ class VirtFtdiPort:
         0x0700: 16,
         0x0800: 8,
         0x0900: 16,
-        0x1000: 8}
+        0x1000: 8,
+        0x3600: 8}
     """Interterface pin count."""
 
     UART_PINS = IntEnum('UartPins', 'TXD RXD RTS CTS DTR DSR DCD RI', start=0)
@@ -972,6 +974,7 @@ class VirtFtdi:
         0x0800: Properties(4, 8, 0),   # FT4232H
         0x0900: Properties(1, 8, 10),  # FT232H
         0x1000: Properties(1, 8, 4),   # FT231X
+        0x3600: Properties(4, 8, 0),   # FT4232HA
     }
     """Width of port/bus (regular, cbus)."""
 

--- a/pyftdi/tests/gpio.py
+++ b/pyftdi/tests/gpio.py
@@ -354,7 +354,7 @@ class GpioSyncTestCase(FtdiTestCase):
 
 
 class GpioMultiportTestCase(FtdiTestCase):
-    """FTDI GPIO test for multi-port FTDI devices, i.e. FT2232H/FT4232H.
+    """FTDI GPIO test for multi-port FTDI devices, i.e. FT2232H/FT4232H/FT4232HA.
 
        Please ensure that the HW you connect to the FTDI port A does match
        the encoded configuration. Check your HW setup before running this test

--- a/pyftdi/tests/i2c.py
+++ b/pyftdi/tests/i2c.py
@@ -241,7 +241,7 @@ class I2cClockStrechingGpioCheck(TestCase):
 
 class I2cDualMaster(TestCase):
     """Check the behaviour of 2 I2C masters. Requires a multi port FTDI device,
-       i.e. FT2232H or FT4232H. See issue #159.
+       i.e. FT2232H, FT4232H or FT4232HA. See issue #159.
     """
 
     def test(self):

--- a/pyftdi/tests/mockusb.py
+++ b/pyftdi/tests/mockusb.py
@@ -101,16 +101,18 @@ class MockUsbToolsTestCase(FtdiTestCase):
                 '232h': 0x6014,
                 '2232h': 0x6010,
                 '4232h': 0x6011,
+                '4232ha': 0x6048,
             }
         }
         devs = UsbTools.list_devices('ftdi:///?', vids, pids, vid)
-        self.assertEqual(len(devs), 6)
+        self.assertEqual(len(devs), 7)
         ifmap = {
             0x6001: 1,
             0x6010: 2,
             0x6011: 4,
             0x6014: 1,
-            0x6015: 1
+            0x6015: 1,
+            0x6048: 4
         }
         for dev, desc in devs:
             strings = UsbTools.build_dev_strings('ftdi', vids, pids,
@@ -143,12 +145,14 @@ class MockFtdiDiscoveryTestCase(FtdiTestCase):
     def test_list_devices(self):
         """List FTDI devices."""
         devs = Ftdi.list_devices('ftdi:///?')
-        self.assertEqual(len(devs), 6)
+        self.assertEqual(len(devs), 7)
         devs = Ftdi.list_devices('ftdi://:232h/?')
         self.assertEqual(len(devs), 2)
         devs = Ftdi.list_devices('ftdi://:2232h/?')
         self.assertEqual(len(devs), 1)
         devs = Ftdi.list_devices('ftdi://:4232h/?')
+        self.assertEqual(len(devs), 1)
+        devs = Ftdi.list_devices('ftdi://:4232ha/?')
         self.assertEqual(len(devs), 1)
         out = StringIO()
         Ftdi.show_devices('ftdi:///?', out)
@@ -156,9 +160,9 @@ class MockFtdiDiscoveryTestCase(FtdiTestCase):
         lines.pop(0)  # "Available interfaces"
         while lines and not lines[-1]:
             lines.pop()
-        self.assertEqual(len(lines), 10)
+        self.assertEqual(len(lines), 14)
         portmap = defaultdict(int)
-        reference = {'232': 1, '2232': 2, '4232': 4, '232h': 2, 'ft-x': 1}
+        reference = {'232': 1, '2232': 2, '4232': 4, '232h': 2, 'ft-x': 1, '4232ha': 4}
         for line in lines:
             url = line.split(' ')[0].strip()
             parts = urlsplit(url)
@@ -250,7 +254,7 @@ class MockTwoPortDeviceTestCase(FtdiTestCase):
 
 
 class MockFourPortDeviceTestCase(FtdiTestCase):
-    """Test FTDI APIs with a quad-port FTDI device (FT4232H)
+    """Test FTDI APIs with a quad-port FTDI device (FT4232H, FT4232HA)
     """
 
     @classmethod
@@ -296,7 +300,7 @@ class MockManyDevicesTestCase(FtdiTestCase):
         lines.pop(0)  # "Available interfaces"
         while lines and not lines[-1]:
             lines.pop()
-        self.assertEqual(len(lines), 10)
+        self.assertEqual(len(lines), 14)
         for line in lines:
             self.assertTrue(line.startswith('ftdi://'))
             # skip description, i.e. consider URL only
@@ -304,7 +308,7 @@ class MockManyDevicesTestCase(FtdiTestCase):
             urlparts = urlsplit(url)
             self.assertEqual(urlparts.scheme, 'ftdi')
             parts = urlparts.netloc.split(':')
-            if parts[1] == '4232':
+            if (parts[1] == '4232') or (parts[1] == '4232ha'):
                 # def file contains no serial number, so expect bus:addr syntax
                 self.assertEqual(len(parts), 4)
                 self.assertRegex(parts[2], r'^\d$')

--- a/pyftdi/tests/resources/ft4232ha.yaml
+++ b/pyftdi/tests/resources/ft4232ha.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+devices:
+  - bus: 1
+    address: 1
+    descriptor:
+      vid: 0x403
+      pid: 0x6048
+      version: 0x3600
+      manufacturer: FTDI
+      product: FT4232HA
+      serialnumber: FT7E0S92
+    configurations:
+      - interfaces:
+        - repeat: 4
+

--- a/pyftdi/tests/resources/ftmany.yaml
+++ b/pyftdi/tests/resources/ftmany.yaml
@@ -60,6 +60,17 @@ devices:
       manufacturer: FTDI
       product: FT2232R
       serialnumber: FT1OPQ
+  - bus: 3
+    address: 5
+    descriptor:
+      vid: 0x403
+      pid: 0x6048
+      version: 0x3600
+      manufacturer: FTDI
+      product: FT4232HA
+    configurations:
+      - interfaces:
+        - repeat: 4
 
 
 

--- a/pyftdi/tracer.py
+++ b/pyftdi/tracer.py
@@ -29,7 +29,8 @@ class FtdiMpsseTracer:
         0x0700: 2,
         0x0800: 2,
         0x0900: 1,
-        0x1000: 0}
+        0x1000: 0,
+        0x3600: 2}
     """Count of MPSSE engines."""
 
     def __init__(self, version):

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -136,8 +136,8 @@ class UsbTools:
            the USB device in random order. serial argument is more reliable
            selector and should always be prefered.
 
-           Some FTDI devices support several interfaces/ports (such as FT2232H
-           and FT4232H). The interface argument selects the FTDI port to use,
+           Some FTDI devices support several interfaces/ports (such as FT2232H,
+           FT4232H and FT4232HA). The interface argument selects the FTDI port to use,
            starting from 1 (not 0).
 
            :param devdesc: Device descriptor that identifies the device by


### PR DESCRIPTION
Aim of this pull request is to add support for FTDI FT4232HA chip (https://ftdichip.com/products/ft4232haq/) which is almost similar to FT4232H, but differs with USB pid (0x6048) and device version (0x3600).