### PR TITLE
tests: allow tests to run under pytest

### DIFF
--- a/pyftdi/tests/eeprom_mock.py
+++ b/pyftdi/tests/eeprom_mock.py
@@ -18,7 +18,7 @@ from pyftdi.ftdi import FtdiError
 VirtLoader = None
 
 
-class FtdiTestCase(TestCase):
+class FtdiTestCase:
     """Common features for all tests.
     """
 
@@ -338,39 +338,39 @@ class NonMirroredEepromTestCase(FtdiTestCase):
         self.assertNotEqual(normal_mirror_s1, normal_mirror_s2)
 
 
-class EepromMirrorFt232hTestCase(EepromMirrorTestCase):
+class EepromMirrorFt232hTestCase(EepromMirrorTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft232h.yaml'
 
 
-class EepromMirrorFt2232hTestCase(EepromMirrorTestCase):
+class EepromMirrorFt2232hTestCase(EepromMirrorTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft2232h.yaml'
 
 
-class EepromMirrorFt4232hTestCase(EepromMirrorTestCase):
+class EepromMirrorFt4232hTestCase(EepromMirrorTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft4232h.yaml'
 
 
-class EepromMirrorFt232rTestCase(NonMirroredEepromTestCase):
+class EepromMirrorFt232rTestCase(NonMirroredEepromTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft232r.yaml'
     DEVICE_CAN_MIRROR = False
 
 
-class EepromMirrorFt230xTestCase(NonMirroredEepromTestCase):
+class EepromMirrorFt230xTestCase(NonMirroredEepromTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft230x.yaml'
     DEVICE_CAN_MIRROR = False
 
 
-class EepromNonMirroredFt232hTestCase(NonMirroredEepromTestCase):
+class EepromNonMirroredFt232hTestCase(NonMirroredEepromTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft232h.yaml'
     DEVICE_CAN_MIRROR = True
 
 
-class EepromNonMirroredFt2232hTestCase(NonMirroredEepromTestCase):
+class EepromNonMirroredFt2232hTestCase(NonMirroredEepromTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft2232h.yaml'
     DEVICE_CAN_MIRROR = True
 
 
-class EepromNonMirroredFt4232hTestCase(NonMirroredEepromTestCase):
+class EepromNonMirroredFt4232hTestCase(NonMirroredEepromTestCase, TestCase):
     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft4232h.yaml'
     DEVICE_CAN_MIRROR = True
 

--- a/pyftdi/tests/eeprom_mock.py
+++ b/pyftdi/tests/eeprom_mock.py
@@ -407,7 +407,7 @@ def virtualize():
         raise AssertionError('Cannot load virtual USB backend')
 
 
-def main():
+def setup_module():
     import doctest
     doctest.testmod(modules[__name__])
     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
@@ -426,6 +426,10 @@ def main():
     FtdiLogger.set_level(loglevel)
     FtdiLogger.set_formatter(formatter)
     virtualize()
+
+
+def main():
+    setup_module()
     try:
         ut_main(defaultTest='suite')
     except KeyboardInterrupt:

--- a/pyftdi/tests/gpio.py
+++ b/pyftdi/tests/gpio.py
@@ -633,7 +633,7 @@ def virtualize():
         raise AssertionError('Cannot load virtual USB backend') from exc
 
 
-def main():
+def setup_module():
     import doctest
     doctest.testmod(modules[__name__])
     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
@@ -652,6 +652,10 @@ def main():
     FtdiLogger.set_level(loglevel)
     FtdiLogger.set_formatter(formatter)
     virtualize()
+
+
+def main():
+    setup_module()
     try:
         ut_main(defaultTest='suite')
     except KeyboardInterrupt:

--- a/pyftdi/tests/mockusb.py
+++ b/pyftdi/tests/mockusb.py
@@ -839,7 +839,7 @@ def suite():
     return suite_
 
 
-def main():
+def setup_module():
     testmod(modules[__name__])
     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
     if debug:
@@ -866,6 +866,10 @@ def main():
         MockLoader = backend.create_loader()
     except AttributeError as exc:
         raise AssertionError('Cannot load virtual USB backend') from exc
+
+
+def main():
+    setup_module()
     ut_main(defaultTest='suite')
 
 


### PR DESCRIPTION
This makes it possible to run tests that do not require physical devices under pytest. These tests will now function under pytest:
 - eeprom_mock
 - gpio
 - mockusb
In addition, one non-device-requiring test already functioned properly under pytest:
 - toolsimport

Two main changes are made:
 - In the three tests, environment setup (mostly to establish the virtual device mock) now happens in `setup_module` instead of `main`. pytest does not run `main`, but will run `setup_module`. This was done without breaking any compatibility with existing test environments by making `main` call `setup_module`.
 - In eeprom_mock, the inheritance model is changed slightly to avoid pytest discovering and running tests in untestable base classes. These tests are not able to run in the base classes and wind up producing errors, because they depend on variables only validly set in subclasses.