### PR TITLE
eeprom: add support to use CBUS IntEnum in _set_cbus_func

### DIFF
--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -486,7 +486,7 @@ class FtdiEeprom:
         """
         mobj = match(r'cbus_func_(\d)', name)
         if mobj:
-            if not isinstance(value, str):
+            if not isinstance(value, str) and not isinstance(value, IntEnum):
                 raise ValueError("'{name}' should be specified as a string")
             self._set_cbus_func(int(mobj.group(1)), value, out)
             self._dirty.add(name)
@@ -871,7 +871,7 @@ class FtdiEeprom:
             return manufacturer.decode('utf16', errors='ignore')
         return ''
 
-    def _set_cbus_func(self, cpin: int, value: str,
+    def _set_cbus_func(self, cpin: int, value: str | IntEnum,
                        out: Optional[TextIO]) -> None:
         cmap = {0x600: (self.CBUS, 5, 0x14, 4),    # FT232R
                 0x900: (self.CBUSH, 10, 0x18, 4),  # FT232H
@@ -893,7 +893,11 @@ class FtdiEeprom:
         if not 0 <= cpin < count:
             raise ValueError(f"Unsupported CBUS pin '{cpin}'")
         try:
-            code = cbus[value.upper()].value
+            if isinstance(value, str):
+                value = value.upper()
+            elif isinstance(value, IntEnum):
+                value = value.name
+            code = cbus[value].value
         except KeyError as exc:
             raise ValueError(f"CBUS pin '{cpin}'' does not have function "
                               f"{value}'") from exc


### PR DESCRIPTION
This commit adds the capability of using FtdiEeprom.CBUS, CBUSH and CBUSX while setting cbus functionality as shown in the example below.
	eeprom = FtdiEeprom()
	eeprom.connect(f) # f is the instance of Ftdi
	eeprom.set_property("cbus_func_0", eeprom.CBUSX.GPIO)

Previously, we had to use the string to set the property for specific CBUS. And when we want to use it like the example above it was giving the following error messages:
```
Traceback (most recent call last):
  File "/home/talha/projects/pyftdi/test.py", line 45, in <module>
    eeprom.set_property("cbus_func_0", eeprom.CBUSX.GPIO)
  File "/home/talha/projects/pyftdi/pyftdi/eeprom.py", line 490, in set_property
    raise ValueError("'{name}' should be specified as a string")
ValueError: '{name}' should be specified as a string
```
```
Traceback (most recent call last):
  File "/home/talha/projects/pyftdi/test.py", line 45, in <module>
    eeprom.set_property("cbus_func_0", eeprom.CBUSX.GPIO)
  File "/home/talha/projects/pyftdi/pyftdi/eeprom.py", line 491, in set_property
    self._set_cbus_func(int(mobj.group(1)), value, out)
  File "/home/talha/projects/pyftdi/pyftdi/eeprom.py", line 896, in _set_cbus_func
    code = cbus[value.upper()].value
AttributeError: 'CBusX' object has no attribute 'upper'
```
