### PR TITLE
eeprom: bugfix & some improvements for ft232h / ft2232h

### DIFF
--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -535,15 +535,14 @@ class FtdiEeprom:
             val = to_bool(value, permissive=False, allow_int=True)
             offset, bit = confs[name]
             mask = 1 << bit
+            idx = 0x08 + offset
             if val:
-                idx = 0x08 + offset
                 self._eeprom[idx] |= mask
                 if self.is_mirroring_enabled:
                     # duplicate in 'sector 2'
                     idx2 = self.mirror_sector + idx
                     self._eeprom[idx2] |= mask
             else:
-                idx = 0x0a + offset
                 self._eeprom[idx] &= ~mask
                 if self.is_mirroring_enabled:
                     # duplicate in 'sector 2'


### PR DESCRIPTION
Hi!

Please check this patch that contains two commits.

1. The first commit fixes a bug with incorrect memory offset computation when setting 'config' bits in EEPROM (or, to be precise, when clearing them). Those include e.g. `remote_wakeup`, `self_powered`, `suspend_pull_down`, etc.
2. The second commit adds a couple of missing functionalities: it allows to set & write `channel_*_type`, `channel_*_driver`, `suspend_dbus7` and `chip` into EEPROM for FT2232H chip. I've also tried to support FT232H but I haven't tested that one.

The reason why I'd like to have these functionalities is to be able to create an EEPROM image for a blank FT2232H from scratch using only pyftdi, without help from proprietary FTDI tools or C libftdi.