### PR TITLE
fix(i2c.py): remove exception for valid API call

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -757,8 +757,6 @@ class I2cController:
         if not self.configured:
             raise I2cIOError("FTDI controller not initialized")
         self.validate_address(address)
-        if readlen < 1:
-            raise I2cIOError('Nothing to read')
         if readlen > (self.PAYLOAD_MAX_LENGTH/3-1):
             raise I2cIOError("Input payload is too large")
         if address is None:


### PR DESCRIPTION
Fixes Issue #359

I considered converting it to a `self.log.warning()` but the API documentation states a `readlen` of 0 is valid, so it wouldn't make sense to warn the developer about that. 

Blame indicates these lines are 8 years old (https://github.com/eblot/pyftdi/commit/0701df62455583927cc91092c91de8840670f9f5), so it was probably just overlooked, unnecessary developer safety net.

P.S. Great work on this library!!!! 🎉 🎉 🎉 