### PR TITLE
Add support for active high CS

### DIFF
--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -478,7 +478,7 @@ class FtdiEeprom:
         mobj = match(r'cbus_func_(\d)', name)
         if mobj:
             if not isinstance(value, str):
-                raise ValueError("'{name}' should be specified as a string")
+                raise ValueError(f"'{name}' should be specified as a string")
             self._set_cbus_func(int(mobj.group(1)), value, out)
             self._dirty.add(name)
             return

--- a/pyftdi/ftdi.py
+++ b/pyftdi/ftdi.py
@@ -2267,7 +2267,7 @@ class Ftdi:
                 raise FtdiError('Unable to set baudrate')
             return actual
         except USBError as exc:
-            raise FtdiError('UsbError: {exc}') from exc
+            raise FtdiError(f'UsbError: {exc}') from exc
 
     def _set_frequency(self, frequency: float) -> float:
         """Convert a frequency value into a TCK divisor setting"""

--- a/pyftdi/tests/backend/ftdivirt.py
+++ b/pyftdi/tests/backend/ftdivirt.py
@@ -1107,7 +1107,7 @@ class VirtFtdi:
                 try:
                     size = cls.EXT_EEPROMS[model.lower()]
                 except KeyError as exc:
-                    raise ValueError('Unsupported EEPROM model: {model}') \
+                    raise ValueError(f'Unsupported EEPROM model: {model}') \
                             from exc
             data = eeprom.get('data', b'')
         if version in cls.INT_EEPROMS:

--- a/pyftdi/tests/backend/mpsse.py
+++ b/pyftdi/tests/backend/mpsse.py
@@ -20,7 +20,7 @@ class VirtMpsseTracer(FtdiMpsseTracer):
 
     def __init__(self, port: 'VirtFtdiPort', version: int):
         super().__init__(version)
-        self.log = getLogger('pyftdi.virt.mpsse.{port.iface}')
+        self.log = getLogger(f'pyftdi.virt.mpsse.{port.iface}')
         self._port = port
 
     def _get_engine(self, iface: int):

--- a/pyftdi/tests/backend/usbvirt.py
+++ b/pyftdi/tests/backend/usbvirt.py
@@ -353,7 +353,7 @@ class VirtBackend(IBackend):
         for dev in self._devices:
             if dev.bus == bus and dev.address == address:
                 return dev.ftdi
-        raise ValueError('No FTDI @ {bus:address}')
+        raise ValueError(f'No FTDI @ {bus:address}')
 
     def enumerate_devices(self) -> VirtDevice:
         yield from self._devices

--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -319,7 +319,7 @@ class UsbTools:
             if len(cvendors) == 1:
                 vendor = cvendors.pop()
         if vendor not in pdict:
-            vstr = '0x{vendor:04x}' if vendor is not None else '?'
+            vstr = f'0x{vendor:04x}' if vendor is not None else '?'
             raise UsbToolsError(f'Vendor ID {vstr} not supported')
         if not product:
             cproducts = {candidate[1] for candidate in candidates
@@ -327,7 +327,7 @@ class UsbTools:
             if len(cproducts) == 1:
                 product = cproducts.pop()
         if product not in pdict[vendor].values():
-            pstr = '0x{vendor:04x}' if product is not None else '?'
+            pstr = f'0x{vendor:04x}' if product is not None else '?'
             raise UsbToolsError(f'Product ID {pstr} not supported')
         devdesc = UsbDeviceDescriptor(vendor, product, desc.bus, desc.address,
                                       desc.sn, idx, desc.description)


### PR DESCRIPTION
We have a few custom devices that use active-high CS. I only looked after an initial implementation and then saw #86 and #258.

After checking those I saw that also the newer PR (#258) is too old to cover some of the current API, so I stuck with my implementation but took the API feedback from #258 on board and implemented the setting as an iterable over CS slot numbers.

I verified the changes with some devices here, as well as via logic analyzer and the added testcase.

I also fixed some forgotten `f`s in f-strings and a documentation typo.

Exchange test:
![image](https://github.com/user-attachments/assets/c00d8ce8-9f23-4afc-8c43-773914317749)

Read test:
![image](https://github.com/user-attachments/assets/26ef27ad-f22b-4814-8e38-95ce18e950fc)

Write test:
![image](https://github.com/user-attachments/assets/65c13f10-b521-4295-870f-b2bafafcf0a0)

Mixed test:
![image](https://github.com/user-attachments/assets/d7989f2f-1ea0-4486-b101-53be914c7269)
