### PR TITLE
eeprom: Fall back to device version of type not set in eeprom

### DIFF
--- a/pyftdi/eeprom.py
+++ b/pyftdi/eeprom.py
@@ -942,7 +942,10 @@ class FtdiEeprom:
             return
         name = None
         try:
-            name = Ftdi.DEVICE_NAMES[cfg['type']].replace('-', '')
+            type_ = cfg['type']
+            if type_ == 0:
+                type_ = self.device_version
+            name = Ftdi.DEVICE_NAMES[type_].replace('-', '')
             if name.startswith('ft'):
                 name = name[2:]
             func = getattr(self, f'_decode_{name}')


### PR DESCRIPTION
When the type isn't set in the eeprom determine it from the device version instead.

This fixes programming some ftdi 232R chips that don't have the type set in the eeprom (Fixes: #309 
