### PR TITLE
tests: Fix for Python 3.13 (unittest.makeSuite was removed)

### DIFF
--- a/pyftdi/tests/toolsimport.py
+++ b/pyftdi/tests/toolsimport.py
@@ -13,7 +13,7 @@ from doctest import testmod
 from importlib import import_module
 from os.path import dirname, join as joinpath
 from sys import modules, path as syspath
-from unittest import TestCase, TestSuite, makeSuite, main as ut_main
+from unittest import TestCase, TestLoader, TestSuite, main as ut_main
 
 
 class ToolsTestCase(TestCase):
@@ -57,7 +57,7 @@ class ToolsTestCase(TestCase):
 
 def suite():
     suite_ = TestSuite()
-    suite_.addTest(makeSuite(ToolsTestCase, 'test'))
+    suite_.addTest(TestLoader().loadTestsFromModule(modules[__name__]))
     return suite_
 
 

--- a/pyftdi/tests/uart.py
+++ b/pyftdi/tests/uart.py
@@ -18,7 +18,7 @@ from struct import calcsize as scalc, pack as spack, unpack as sunpack
 from sys import modules, platform, stdout
 from time import sleep, time as now
 from threading import Thread
-from unittest import TestCase, TestSuite, skipIf, makeSuite, main as ut_main
+from unittest import TestCase, TestLoader, TestSuite, skipIf, main as ut_main
 from pyftdi import FtdiLogger
 from pyftdi.ftdi import Ftdi
 from pyftdi.misc import to_bool
@@ -343,8 +343,7 @@ class BaudrateTestCase(FtdiTestCase):
 
 def suite():
     suite_ = TestSuite()
-    suite_.addTest(makeSuite(BaudrateTestCase, 'test'))
-    suite_.addTest(makeSuite(UartTestCase, 'test'))
+    suite_.addTest(TestLoader().loadTestsFromModule(modules[__name__]))
     return suite_
 
 


### PR DESCRIPTION
```
ImportError while importing test module '…/pyftdi/pyftdi/tests/toolsimport.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
…/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
pyftdi/tests/toolsimport.py:16: in <module>
    from unittest import TestCase, TestSuite, makeSuite, main as ut_main
E   ImportError: cannot import name 'makeSuite' from 'unittest' (…/lib/python3.13/unittest/__init__.py)
```

https://github.com/python/cpython/issues/104835
https://github.com/python/cpython/pull/104836
https://github.com/python/cpython/commit/b1cb30ec8639e4e65f62e8f6cd44e979640431c8
https://docs.python.org/3/whatsnew/3.13.html#unittest

@eblot