### PR TITLE
bugfix(eeprom): make sure to close eeprom #394

### DIFF
--- a/pyftdi/bin/ftconf.py
+++ b/pyftdi/bin/ftconf.py
@@ -186,6 +186,8 @@ def main():
         sys_exit(1)
     except KeyboardInterrupt:
         sys_exit(2)
+    finally:
+        eeprom.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes a bug in ftconf.py where the eeprom device was not closed before exiting.  This meant the kernel driver was not re-attached causing device disconnection.