### PR TITLE
i2c: fix reading >116 bytes with the non-optimized read path

### DIFF
--- a/pyftdi/i2c.py
+++ b/pyftdi/i2c.py
@@ -1130,7 +1130,7 @@ class I2cController:
                         # repeated till the end of the transfer
                         cmd = bytearray()
                         cmd.extend(read_not_last * chunk_size)
-                        size = chunk_size
+                    size = chunk_size
                 else:
                     cmd = bytearray()
                     cmd.extend(read_not_last * (rem-1))


### PR DESCRIPTION
size wasn't being clamped to the chunk size after the first read, so pyftdi would read another chunk size and then zero out the remainder.  This fixes reading more than 116 bytes with the non-optimized path, primarily to avoid red herrings when debugging other things (since this path is not the standard one).