### PR TITLE
fix(usbtools): Handle Missing LangID in UsbTools.get_string()

### DIFF
--- a/pyftdi/usbtools.py
+++ b/pyftdi/usbtools.py
@@ -543,8 +543,9 @@ class UsbTools:
             if cls.UsbApi == 2:
                 return usb_get_string(device, stridx)
             return usb_get_string(device, 64, stridx)
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, ValueError):
             # do not abort if EEPROM data is somewhat incoherent
+            # or if device has no langid or no permission
             return ''
 
     @classmethod


### PR DESCRIPTION
**Issue:**
When multiple FTDI devices are connected, such as a custom FTDI-based board alongside an ESP32 debugger, the debugger can cause USB enumeration failures due to missing or inaccessible language IDs (LangIDs). Specifically, when these LangIDs are missing, calling `UsbTools.get_string()` raises a `ValueError`. This impacts critical functions including:

```
Ftdi.list_devices()

Ftdi.open_from_url()

serialext.serial_for_url()
```

and any other method relying on USB device enumeration.

**Fix**:
This PR modifies `UsbTools.get_string()` to gracefully handle cases where LangIDs are missing. Instead of raising an exception, it catches the ValueError and returns an empty string. This prevents enumeration-related crashes and significantly improves compatibility with setups containing mixed FTDI devices, such as those involving ESP debuggers.

**Additional Notes:**

On Linux environments or Docker setups, proper udev rules might mitigate the issue. However, this fix enhances compatibility across Windows and macOS as well.

**Impact:**

Prevents crashes during USB enumeration.

Ensures smoother operation when ESP debuggers or similar devices with incomplete USB descriptors are connected.

Enhances overall robustness of pyftdi in diverse hardware environments.

**Related Issues:**

Potentially resolves issues reported in #358 and #311.

